### PR TITLE
Allow alternative namespace(s) for Module installers

### DIFF
--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -88,9 +88,10 @@ class Addon implements PresentableInterface
      * @param  null $key
      * @return string
      */
-    public function getNamespace($key = null)
-    {
-        return "{$this->getVendor()}.{$this->getType()}.{$this->getSlug()}" . ($key ? '::' . $key : $key);
+    public function getNamespace($key = null, $namespace = null)
+    {   
+        $namespace = ($namespace)?$namespace : $this->getSlug();
+        return "{$this->getVendor()}.{$this->getType()}.{$namespace}" . ($key ? '::' . $key : $key);
     }
 
     /**

--- a/src/Field/FieldInstaller.php
+++ b/src/Field/FieldInstaller.php
@@ -72,8 +72,8 @@ class FieldInstaller implements InstallableInterface
             $config = array_get($field, 'config', []);
             $locked = (array_get($field, 'locked', true));
 
-            $namespace = array_get($field, 'namespace', $this->addon->getSlug());
-            $name      = array_get($field, 'name', $this->addon->getNamespace("field.{$slug}.name"));
+            $namespace = array_get($field, 'namespace', ($this->namespace)?$this->namespace:$this->addon->getSlug());
+            $name      = array_get($field, 'name', $this->addon->getNamespace("field.{$slug}.name", $namespace));
 
             $this->manager->create(compact('slug', 'type', 'namespace', 'name', 'rules', 'config', 'locked'));
         }
@@ -90,7 +90,7 @@ class FieldInstaller implements InstallableInterface
     {
         foreach ($this->getFields() as $slug => $field) {
 
-            $namespace = array_get($field, 'namespace', $this->addon->getSlug());
+            $namespace = array_get($field, 'namespace', ($this->namespace)?$this->namespace:$this->addon->getSlug());
 
             $this->manager->delete($namespace, $slug);
         }

--- a/src/Stream/StreamInstaller.php
+++ b/src/Stream/StreamInstaller.php
@@ -15,6 +15,15 @@ use Anomaly\Streams\Platform\Field\FieldManager;
 class StreamInstaller implements InstallableInterface
 {
 
+
+    /**
+     * The namespace if different than
+     * the addon slug.
+     *
+     * @var null
+     */
+    protected $namespace = null;
+   
     /**
      * The stream configuration.
      *
@@ -86,7 +95,7 @@ class StreamInstaller implements InstallableInterface
     public function uninstall()
     {
         $stream    = array_get($this->stream, 'slug');
-        $namespace = array_get($this->stream, 'namespace', $this->addon->getSlug());
+        $namespace = array_get($this->stream, 'namespace', ($this->namespace)?$this->namespace:$this->addon->getSlug());
 
         foreach ($this->getAssignments() as $field => $assignment) {
             $this->fieldManager->unassign($namespace, $stream, $field, $assignment);
@@ -101,9 +110,9 @@ class StreamInstaller implements InstallableInterface
     protected function installStream()
     {
         $slug        = array_get($this->stream, 'slug');
-        $namespace   = array_get($this->stream, 'namespace', $this->addon->getSlug());
-        $name        = array_get($this->stream, 'name', $this->addon->getNamespace("stream.{$slug}.name"));
-        $description = array_get($this->stream, 'name', $this->addon->getNamespace("stream.{$slug}.description"));
+        $namespace   = array_get($this->stream, 'namespace', ($this->namespace)?$this->namespace:$this->addon->getSlug());
+        $name        = array_get($this->stream, 'name', $this->addon->getNamespace("stream.{$slug}.name", $namespace));
+        $description = array_get($this->stream, 'name', $this->addon->getNamespace("stream.{$slug}.description", $namespace));
 
         $orderBy     = array_get($this->stream, 'order_by', 'id');
         $titleColumn = array_get($this->stream, 'title_column', 'id');
@@ -143,23 +152,24 @@ class StreamInstaller implements InstallableInterface
             $field      = $assignment;
             $assignment = [];
         }
+        
+        $namespace = array_get($this->stream, 'namespace', ($this->namespace)?$this->namespace:$this->addon->getSlug());
 
         $unique       = (array_get($assignment, 'unique', false));
         $required     = (array_get($assignment, 'required', false));
         $translatable = (array_get($assignment, 'translatable', false));
 
-        $label        = array_get($assignment, 'label', $this->addon->getNamespace("field.{$field}.label"));
-        $placeholder  = array_get($assignment, 'placeholder', $this->addon->getNamespace("field.{$field}.placeholder"));
+        $label        = array_get($assignment, 'label', $this->addon->getNamespace("field.{$field}.label", $namespace));
+        $placeholder  = array_get($assignment, 'placeholder', $this->addon->getNamespace("field.{$field}.placeholder", $namespace));
         $instructions = array_get(
             $assignment,
             'instructions',
-            $this->addon->getNamespace("field.{$field}.instructions")
+            $this->addon->getNamespace("field.{$field}.instructions", $namespace)
         );
 
         $assignment = compact('label', 'placeholder', 'instructions', 'unique', 'required', 'translatable');
 
         $stream    = array_get($this->stream, 'slug');
-        $namespace = array_get($this->stream, 'namespace', $this->addon->getSlug());
 
         $this->fieldManager->assign(
             $namespace,


### PR DESCRIPTION
Changes to FieldInstaller, StreamInstaller and Addon classes (core) to enable a Module to install Fields and Streams in a namespace that's different than the module slug.