### PR TITLE
Feature: Addon migrations

### DIFF
--- a/resources/assets/migration/stubs/blank.stub
+++ b/resources/assets/migration/stubs/blank.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Anomaly\Streams\Platform\Database\Migration\Migration;
+
+class {{class}} extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		//
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		//
+	}
+
+}

--- a/resources/assets/migration/stubs/create.stub
+++ b/resources/assets/migration/stubs/create.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Anomaly\Streams\Platform\Database\Migration\Migration;
+
+class {{class}} extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('{{table}}', function(Blueprint $table)
+		{
+			$table->increments('id');
+			$table->timestamps();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('{{table}}');
+	}
+
+}

--- a/resources/assets/migration/stubs/update.stub
+++ b/resources/assets/migration/stubs/update.stub
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Anomaly\Streams\Platform\Database\Migration\Migration;
+
+class {{class}} extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('{{table}}', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('{{table}}', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+}

--- a/src/Addon/AddonCollection.php
+++ b/src/Addon/AddonCollection.php
@@ -47,6 +47,7 @@ class AddonCollection extends Collection
      * Find an addon by it's slug.
      *
      * @param  $slug
+     *
      * @return null|Addon
      */
     public function findBySlug($slug)
@@ -64,6 +65,7 @@ class AddonCollection extends Collection
      * Order addon's by their slug.
      *
      * @param  string $direction
+     *
      * @return AddonCollection
      */
     public function orderBySlug($direction = 'asc')
@@ -89,7 +91,8 @@ class AddonCollection extends Collection
      * Return only extensions with config
      * matching the given pattern.
      *
-     * @param $string
+     * @param $pattern
+     *
      * @return static
      */
     public function withConfig($pattern = '*')
@@ -104,4 +107,19 @@ class AddonCollection extends Collection
 
         return self::make($addons);
     }
+
+    /**
+     * @return static
+     */
+    public function merged()
+    {
+        $addons = [];
+
+        foreach (config('streams.addon_types') as $type) {
+            $addons = array_merge($addons, app("{$type}.collection")->toArray());
+        }
+
+        return new AddonCollection($addons);
+    }
+
 }

--- a/src/Addon/AddonLoader.php
+++ b/src/Addon/AddonLoader.php
@@ -16,8 +16,6 @@ class AddonLoader extends ClassLoader
     /**
      * Load the addon.
      *
-     * @param $type
-     * @param $slug
      * @param $path
      */
     public function load($path)

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -60,6 +60,8 @@ class AddonManager
 
     /**
      * Register all addons of a given type.
+     *
+     * @param $type
      */
     public function register($type)
     {

--- a/src/Addon/Block/BlockServiceProvider.php
+++ b/src/Addon/Block/BlockServiceProvider.php
@@ -38,6 +38,11 @@ class BlockServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Block\BlockCollection'
         );
 
+        $this->app->bind(
+            'block.collection',
+            'Anomaly\Streams\Platform\Addon\Block\BlockCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Block\BlockEventProvider');
     }
 }

--- a/src/Addon/Distribution/DistributionServiceProvider.php
+++ b/src/Addon/Distribution/DistributionServiceProvider.php
@@ -42,6 +42,11 @@ class DistributionServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Distribution\DistributionCollection'
         );
 
+        $this->app->bind(
+            'distribution.collection',
+            'Anomaly\Streams\Platform\Addon\Distribution\DistributionCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Distribution\DistributionEventProvider');
     }
 }

--- a/src/Addon/Extension/ExtensionServiceProvider.php
+++ b/src/Addon/Extension/ExtensionServiceProvider.php
@@ -53,6 +53,11 @@ class ExtensionServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Extension\ExtensionCollection'
         );
 
+        $this->app->bind(
+            'extension.collection',
+            'Anomaly\Streams\Platform\Addon\Extension\ExtensionCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Extension\ExtensionEventProvider');
     }
 }

--- a/src/Addon/FieldType/FieldTypeServiceProvider.php
+++ b/src/Addon/FieldType/FieldTypeServiceProvider.php
@@ -38,6 +38,11 @@ class FieldTypeServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\FieldType\FieldTypeCollection'
         );
 
+        $this->app->bind(
+            'field_type.collection',
+            'Anomaly\Streams\Platform\Addon\FieldType\FieldTypeCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\FieldType\FieldTypeEventProvider');
     }
 }

--- a/src/Addon/Module/ModuleServiceProvider.php
+++ b/src/Addon/Module/ModuleServiceProvider.php
@@ -54,6 +54,11 @@ class ModuleServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Module\ModuleCollection'
         );
 
+        $this->app->bind(
+            'module.collection',
+            'Anomaly\Streams\Platform\Addon\Module\ModuleCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Module\ModuleEventProvider');
     }
 }

--- a/src/Addon/Plugin/PluginServiceProvider.php
+++ b/src/Addon/Plugin/PluginServiceProvider.php
@@ -40,6 +40,11 @@ class PluginServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Plugin\PluginCollection'
         );
 
+        $this->app->bind(
+            'plugin.collection',
+            'Anomaly\Streams\Platform\Addon\Plugin\PluginCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Plugin\PluginEventProvider');
     }
 }

--- a/src/Addon/Theme/ThemeServiceProvider.php
+++ b/src/Addon/Theme/ThemeServiceProvider.php
@@ -46,6 +46,11 @@ class ThemeServiceProvider extends ServiceProvider
             'Anomaly\Streams\Platform\Addon\Theme\ThemeCollection'
         );
 
+        $this->app->bind(
+            'theme.collection',
+            'Anomaly\Streams\Platform\Addon\Theme\ThemeCollection'
+        );
+
         $this->app->register('Anomaly\Streams\Platform\Addon\Theme\ThemeEventProvider');
     }
 }

--- a/src/Console/ConsoleSupportServiceProvider.php
+++ b/src/Console/ConsoleSupportServiceProvider.php
@@ -1,0 +1,25 @@
+<?php namespace Anomaly\Streams\Platform\Console;
+
+
+use Illuminate\Foundation\Providers\ConsoleSupportServiceProvider as BaseConsoleSupportServiceProvider;
+
+class ConsoleSupportServiceProvider extends BaseConsoleSupportServiceProvider
+{
+
+    /**
+     * The provider class names.
+     *
+     * @var array
+     */
+    protected $providers = [
+        'Illuminate\Auth\GeneratorServiceProvider',
+        'Illuminate\Console\ScheduleServiceProvider',
+        'Anomaly\Streams\Platform\Database\Migration\MigrationServiceProvider',
+        'Illuminate\Database\SeedServiceProvider',
+        'Illuminate\Foundation\Providers\ComposerServiceProvider',
+        'Illuminate\Queue\ConsoleServiceProvider',
+        'Illuminate\Routing\GeneratorServiceProvider',
+        'Illuminate\Session\CommandsServiceProvider',
+    ];
+
+}

--- a/src/Database/Migration/Command/CreateAddonMigrationFolder.php
+++ b/src/Database/Migration/Command/CreateAddonMigrationFolder.php
@@ -1,0 +1,32 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command;
+
+/**
+ * Class CreateAddonMigrationFolder
+ *
+ * @package Anomaly\Streams\Platform\Addon\Command
+ */
+class CreateAddonMigrationFolder
+{
+
+    /**
+     * @var null
+     */
+    protected $namespace;
+
+    /**
+     * @param null $namespace
+     */
+    public function __construct($namespace = null)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * @return null
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+}

--- a/src/Database/Migration/Command/GetMigrationName.php
+++ b/src/Database/Migration/Command/GetMigrationName.php
@@ -1,0 +1,47 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command;
+
+/**
+ * Class GetMigrationName
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration\Command
+ */
+class GetMigrationName
+{
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string|null
+     */
+    protected $namespace = null;
+
+    /**
+     * @param $name
+     * @param $namespace
+     */
+    public function __construct($name, $namespace = null)
+    {
+        $this->name = $name;
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+}

--- a/src/Database/Migration/Command/Handler/CreateAddonMigrationFolderHandler.php
+++ b/src/Database/Migration/Command/Handler/CreateAddonMigrationFolderHandler.php
@@ -1,0 +1,58 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command\Handler;
+
+use Anomaly\Streams\Platform\Addon\AddonCollection;
+use Anomaly\Streams\Platform\Database\Migration\Command\CreateAddonMigrationFolder;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+
+/**
+ * Class CreateAddonMigrationFolderHandler
+ *
+ * @package Anomaly\Streams\Platform\Addon\Command\Handler
+ */
+class CreateAddonMigrationFolderHandler
+{
+    use DispatchesCommands;
+
+    /**
+     * @var Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var AddonCollection
+     */
+    protected $addonCollection;
+
+    /**
+     * @param Filesystem      $files
+     * @param AddonCollection $addonCollection
+     */
+    public function __construct(Filesystem $files, AddonCollection $addonCollection)
+    {
+        $this->files = $files;
+        $this->addonCollection = $addonCollection;
+    }
+
+    /**
+     * @param CreateAddonMigrationFolder $command
+     *
+     * @return string|null
+     */
+    public function handle(CreateAddonMigrationFolder $command)
+    {
+        $path = null;
+
+        if ($addon = $this->addonCollection->merged()->get($command->getNamespace())) {
+
+            $path = $addon->getPath('migrations');
+
+            if (!$this->files->isDirectory($path)) {
+                $this->files->makeDirectory($path);
+            }
+        }
+
+        return $path;
+    }
+
+}

--- a/src/Database/Migration/Command/Handler/GetMigrationNameHandler.php
+++ b/src/Database/Migration/Command/Handler/GetMigrationNameHandler.php
@@ -1,0 +1,55 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command\Handler;
+
+use Anomaly\Streams\Platform\Addon\AddonCollection;
+use Anomaly\Streams\Platform\Database\Migration\Command\GetMigrationName;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+
+/**
+ * Class GetMigrationNameHandler
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration\Command\Handler
+ */
+class GetMigrationNameHandler
+{
+    use DispatchesCommands;
+
+    /**
+     * @var AddonCollection
+     */
+    protected $addonCollection;
+
+    /**
+     * @param AddonCollection $addonCollection
+     */
+    public function __construct(AddonCollection $addonCollection)
+    {
+        $this->addonCollection = $addonCollection;
+    }
+
+    /**
+     * @param GetMigrationName $command
+     *
+     * @return string
+     */
+    public function handle(GetMigrationName $command)
+    {
+        $namespace = $command->getNamespace();
+
+        $name = $originalName = $command->getName();
+
+        if ($addon = $this->addonCollection->merged()->get($namespace)) {
+
+            $name = "{$namespace}__{$originalName}";
+
+            // Append the package version if there is one
+            if ($json = $addon->getComposerJson()) {
+                if (property_exists($json, 'version')) {
+                    $name = "{$namespace}__{$json->version}__{$originalName}";
+                }
+            }
+        }
+
+        return $name;
+    }
+
+}

--- a/src/Database/Migration/Command/Handler/TransformMigrationNameToClassHandler.php
+++ b/src/Database/Migration/Command/Handler/TransformMigrationNameToClassHandler.php
@@ -1,0 +1,39 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command\Handler;
+
+
+use Anomaly\Streams\Platform\Database\Migration\Command\TransformMigrationNameToClass;
+
+class TransformMigrationNameToClassHandler
+{
+
+    /**
+     * @param TransformMigrationNameToClass $command
+     *
+     * @return string
+     */
+    public function handle(TransformMigrationNameToClass $command)
+    {
+        $name = $command->getName();
+
+        $finalName = studly_case(str_replace('.', '_', $name));
+
+        $segments = explode('__', $name);
+
+        // Insert the version number if there are three segments or more
+        if (count($segments) >= 3) {
+
+            $key = $segments[0];
+            $version = $segments[1];
+            $migration = $segments[2];
+
+            $finalName =
+                studly_case(str_replace('.', '_', $key)) . '_' .
+                str_replace('.', '_', $version) . '_' .
+                studly_case(str_replace('.', '_', $migration));
+
+        }
+
+        return $finalName;
+    }
+
+}

--- a/src/Database/Migration/Command/TransformMigrationNameToClass.php
+++ b/src/Database/Migration/Command/TransformMigrationNameToClass.php
@@ -1,0 +1,24 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Command;
+
+class TransformMigrationNameToClass
+{
+
+    protected $name;
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+}

--- a/src/Database/Migration/Console/MigrateCommand.php
+++ b/src/Database/Migration/Console/MigrateCommand.php
@@ -1,0 +1,80 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Console;
+
+use Anomaly\Streams\Platform\Addon\Addon;
+use Anomaly\Streams\Platform\Addon\AddonCollection;
+use Anomaly\Streams\Platform\Database\Migration\Migrator;
+use Illuminate\Database\Console\Migrations\MigrateCommand as BaseMigrateCommand;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+use Symfony\Component\Console\Input\InputOption;
+
+class MigrateCommand extends BaseMigrateCommand
+{
+    use DispatchesCommands;
+
+    /**
+     * @var Migrator
+     */
+    protected $migrator;
+
+    public function fire()
+    {
+        $this->migrator->setNamespace('laravel');
+
+        parent::fire();
+
+        if (!$this->input->getOption('no-addons')) {
+
+            $addonCollection = (new AddonCollection())->merged();
+
+            if ($namespaces = $this->input->getOption('addons')) {
+
+                $namespaces = explode(',', $namespaces);
+
+                $addonCollection = $addonCollection->filter(function (Addon $addon) use ($namespaces) {
+
+                    return in_array($addon->getNamespace(), $namespaces);
+                });
+
+            }
+
+            // The pretend option can be used for "simulating" the migration and grabbing
+            // the SQL queries that would fire if the migration were to be run against
+            // a database for real, which is helpful for double checking migrations.
+            $pretend = $this->input->getOption('pretend');
+
+            /** @var Addon $addon */
+            foreach ($addonCollection as $addon) {
+
+                $this->migrator->setNamespace($addon->getNamespace())->run($addon->getPath('migrations'), $pretend);
+
+                // Finally, if the "seed" option has been given, we will re-run the database
+                // seed task to re-populate the database, which is convenient when adding
+                // a migration and a seed at the same time, as it is only this command.
+                // @todo - add this when done with addon seeding
+                /*if ($this->input->getOption('seed')) {
+                    $this->call('db:seed', ['--force' => true]);
+                }*/
+
+                // Once the migrator has run we will grab the note output and send it out to
+                // the console screen, since the migrator itself functions without having
+                // any instances of the OutputInterface contract passed into the class.
+                foreach ($this->migrator->getNotes() as $note) {
+                    $this->output->writeln($note);
+                }
+            }
+
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return array_merge(parent::getOptions(), [
+            ['addons', null, InputOption::VALUE_OPTIONAL, 'The comma separated list of addons to migrate.'],
+            ['no-addons', null, InputOption::VALUE_NONE, 'Don\'t run addon migrations, only laravel migrations.'],
+        ]);
+    }
+
+}

--- a/src/Database/Migration/Console/MigrateCommand.php
+++ b/src/Database/Migration/Console/MigrateCommand.php
@@ -26,7 +26,7 @@ class MigrateCommand extends BaseMigrateCommand
 
             $addonCollection = (new AddonCollection())->merged();
 
-            if ($namespaces = $this->input->getOption('addons')) {
+            if ($namespaces = $this->input->getOption('addon')) {
 
                 $namespaces = explode(',', $namespaces);
 
@@ -72,7 +72,7 @@ class MigrateCommand extends BaseMigrateCommand
     protected function getOptions()
     {
         return array_merge(parent::getOptions(), [
-            ['addons', null, InputOption::VALUE_OPTIONAL, 'The comma separated list of addons to migrate.'],
+            ['addon', null, InputOption::VALUE_OPTIONAL, 'The addon to migrate.'],
             ['no-addons', null, InputOption::VALUE_NONE, 'Don\'t run addon migrations, only laravel migrations.'],
         ]);
     }

--- a/src/Database/Migration/Console/MigrateMakeCommand.php
+++ b/src/Database/Migration/Console/MigrateMakeCommand.php
@@ -1,0 +1,77 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Console;
+
+use Anomaly\Streams\Platform\Database\Migration\Command\CreateAddonMigrationFolder;
+use Anomaly\Streams\Platform\Database\Migration\Command\GetMigrationName;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand as BaseMigrateMakeCommand;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+use Symfony\Component\Console\Input\InputOption;
+
+class MigrateMakeCommand extends BaseMigrateMakeCommand
+{
+    use DispatchesCommands;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        // It's possible for the developer to specify the tables to modify in this
+        // schema operation. The developer may also specify if this table needs
+        // to be freshly created so we can create the appropriate migrations.
+        $name = $this->input->getArgument('name');
+
+        $table = $this->input->getOption('table');
+
+        $create = $this->input->getOption('create');
+
+        $addon = $this->input->getOption('addon');
+
+        if (!$table && is_string($create)) {
+            $table = $create;
+        }
+
+        // Now we are ready to write the migration out to disk. Once we've written
+        // make sure that the migrations are registered by the class loaders.
+        $this->writeMigration($name, $table, $create, $addon);
+    }
+
+    /**
+     * Write the migration file to disk.
+     *
+     * @param  string $name
+     * @param  string $table
+     * @param  bool   $create
+     *
+     * @param null    $namespace
+     *
+     * @return string
+     */
+    protected function writeMigration($name, $table, $create, $namespace = null)
+    {
+        $name = $this->dispatch(new GetMigrationName($name, $namespace));
+
+        if (!$path = $this->dispatch(new CreateAddonMigrationFolder($namespace))) {
+
+            $path = $this->getMigrationPath();
+        }
+
+        $file = pathinfo($this->creator->create($name, $path, $table, $create), PATHINFO_FILENAME);
+
+        $this->line("<info>Created Migration:</info> $file");
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return array_merge(parent::getOptions(), [
+            ['addon', null, InputOption::VALUE_OPTIONAL, 'The addon where the migration will be generated.']
+        ]);
+    }
+
+}

--- a/src/Database/Migration/Console/ResetCommand.php
+++ b/src/Database/Migration/Console/ResetCommand.php
@@ -19,8 +19,8 @@ class ResetCommand extends BaseResetCommand
      */
     public function fire()
     {
-        // Reset specific adddons
-        if ($namespaces = $this->input->getOption('addons')) {
+        // Reset a specific addon
+        if ($namespaces = $this->input->getOption('addon')) {
 
             $pretend = $this->input->getOption('pretend');
 
@@ -58,7 +58,7 @@ class ResetCommand extends BaseResetCommand
     public function getOptions()
     {
         return array_merge(parent::getOptions(), [
-            ['addons', null, InputOption::VALUE_OPTIONAL, 'The comma separated list of addons to migrate.'],
+            ['addon', null, InputOption::VALUE_OPTIONAL, 'The addon to reset migrations.'],
             ['no-addons', null, InputOption::VALUE_NONE, 'Don\'t run addon migrations, only laravel migrations.'],
         ]);
     }

--- a/src/Database/Migration/Console/ResetCommand.php
+++ b/src/Database/Migration/Console/ResetCommand.php
@@ -1,0 +1,66 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration\Console;
+
+use Anomaly\Streams\Platform\Database\Migration\Migrator;
+use Illuminate\Database\Console\Migrations\ResetCommand as BaseResetCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ResetCommand extends BaseResetCommand
+{
+
+    /**
+     * @var Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        // Reset specific adddons
+        if ($namespaces = $this->input->getOption('addons')) {
+
+            $pretend = $this->input->getOption('pretend');
+
+            $namespaces = explode(',', $namespaces);
+
+            foreach ($namespaces as $namespace) {
+
+                while (true) {
+
+                    $count = $this->migrator->rollbackNamespace($namespace, $pretend);
+
+                    // Once the migrator has run we will grab the note output and send it out to
+                    // the console screen, since the migrator itself functions without having
+                    // any instances of the OutputInterface contract passed into the class.
+                    foreach ($this->migrator->getNotes() as $note) {
+                        $this->output->writeln($note);
+                    }
+
+                    if ($count == 0) {
+                        break;
+                    }
+                }
+            }
+
+        } else {
+
+            // Reset everything
+            parent::fire();
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return array_merge(parent::getOptions(), [
+            ['addons', null, InputOption::VALUE_OPTIONAL, 'The comma separated list of addons to migrate.'],
+            ['no-addons', null, InputOption::VALUE_NONE, 'Don\'t run addon migrations, only laravel migrations.'],
+        ]);
+    }
+
+}

--- a/src/Database/Migration/Migration.php
+++ b/src/Database/Migration/Migration.php
@@ -1,0 +1,18 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration;
+
+use Illuminate\Database\Migrations\Migration as BaseMigration;
+
+/**
+ * Class Migration
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration
+ */
+abstract class Migration extends BaseMigration
+{
+
+    public function __construct()
+    {
+
+    }
+
+}

--- a/src/Database/Migration/MigrationCreator.php
+++ b/src/Database/Migration/MigrationCreator.php
@@ -1,0 +1,38 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration;
+
+use Anomaly\Streams\Platform\Database\Migration\Command\TransformMigrationNameToClass;
+use Illuminate\Database\Migrations\MigrationCreator as BaseMigrationCreator;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+
+/**
+ * Class MigrationCreator
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration
+ */
+class MigrationCreator extends BaseMigrationCreator
+{
+    use DispatchesCommands;
+
+    /**
+     * Get the path to the stubs.
+     *
+     * @return string
+     */
+    public function getStubPath()
+    {
+        return __DIR__ . '/../../../resources/assets/migration/stubs';
+    }
+
+    /**
+     * Get the class name of a migration name.
+     *
+     * @param  string $name
+     *
+     * @return string
+     */
+    protected function getClassName($name)
+    {
+        return $this->dispatch(new TransformMigrationNameToClass($name));
+    }
+
+}

--- a/src/Database/Migration/MigrationRepository.php
+++ b/src/Database/Migration/MigrationRepository.php
@@ -1,0 +1,21 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration;
+
+use Illuminate\Database\Migrations\DatabaseMigrationRepository;
+
+class MigrationRepository extends DatabaseMigrationRepository
+{
+
+    /**
+     * @param        $namespace
+     * @param string $order
+     *
+     * @return array|static[]
+     */
+    public function findManyByNamespace($namespace, $order = 'desc')
+    {
+        $query = $this->table()->where('migration', 'like', "%_{$namespace}_%");
+
+        return $query->orderBy('migration', $order)->get();
+    }
+
+}

--- a/src/Database/Migration/MigrationServiceProvider.php
+++ b/src/Database/Migration/MigrationServiceProvider.php
@@ -1,0 +1,106 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration;
+
+use Anomaly\Streams\Platform\Database\Migration\Console\MigrateAddonsCommand;
+use Anomaly\Streams\Platform\Database\Migration\Console\MigrateCommand;
+use Anomaly\Streams\Platform\Database\Migration\Console\MigrateMakeCommand;
+use Anomaly\Streams\Platform\Database\Migration\Console\ResetCommand;
+use Illuminate\Database\MigrationServiceProvider as BaseMigrationServiceProvider;
+
+/**
+ * Class MigrationServiceProvider
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration
+ */
+class MigrationServiceProvider extends BaseMigrationServiceProvider
+{
+
+    /**
+     * Register the migration repository service.
+     *
+     * @return void
+     */
+    protected function registerRepository()
+    {
+        $this->app->singleton('migration.repository', function ($app) {
+            $table = $app['config']['database.migrations'];
+
+            return new MigrationRepository($app['db'], $table);
+        });
+    }
+
+    /**
+     * Register the migrator service.
+     *
+     * @return void
+     */
+    protected function registerMigrator()
+    {
+        // The migrator is responsible for actually running and rollback the migration
+        // files in the application. We'll pass in our database connection resolver
+        // so the migrator can resolve any of these connections when it needs to.
+        $this->app->singleton('migrator', function ($app) {
+            $repository = $app['migration.repository'];
+
+            return new Migrator($repository, $app['db'], $app['files']);
+        });
+    }
+
+    /**
+     * Register the "make" migration command.
+     *
+     * @return void
+     */
+    protected function registerMakeCommand()
+    {
+        $this->registerCreator();
+
+        $this->app->singleton('command.migrate.make', function ($app) {
+            // Once we have the migration creator registered, we will create the command
+            // and inject the creator. The creator is responsible for the actual file
+            // creation of the migrations, and may be extended by these developers.
+            $creator = $app['migration.creator'];
+
+            $composer = $app['composer'];
+
+            return new MigrateMakeCommand($creator, $composer);
+        });
+    }
+
+    /**
+     * Register the "migrate" migration command.
+     *
+     * @return void
+     */
+    protected function registerMigrateCommand()
+    {
+        $this->app->singleton('command.migrate', function ($app) {
+            return new MigrateCommand($app['migrator']);
+        });
+    }
+
+    /**
+     * Register the "reset" migration command.
+     *
+     * @return void
+     */
+    protected function registerResetCommand()
+    {
+        $this->app->singleton('command.migrate.reset', function($app)
+        {
+            return new ResetCommand($app['migrator']);
+        });
+    }
+
+    /**
+     * Register the migration creator.
+     *
+     * @return void
+     */
+    protected function registerCreator()
+    {
+        $this->app->singleton('migration.creator', function ($app) {
+            return new MigrationCreator($app['files']);
+        });
+    }
+
+}

--- a/src/Database/Migration/Migrator.php
+++ b/src/Database/Migration/Migrator.php
@@ -1,0 +1,159 @@
+<?php namespace Anomaly\Streams\Platform\Database\Migration;
+
+use Anomaly\Streams\Platform\Addon\AddonCollection;
+use Anomaly\Streams\Platform\Database\Migration\Command\TransformMigrationNameToClass;
+use Illuminate\Database\Migrations\Migrator as BaseMigrator;
+use Illuminate\Foundation\Bus\DispatchesCommands;
+
+/**
+ * Class Migrator
+ *
+ * @package Anomaly\Streams\Platform\Database\Migration
+ */
+class Migrator extends BaseMigrator
+{
+    use DispatchesCommands;
+
+    /**
+     * @var string|null
+     */
+    protected $namespace;
+
+    /**
+     * @param $namespace
+     *
+     * @return $this
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+
+        return $this;
+    }
+
+    /**
+     * Run an array of migrations.
+     *
+     * @param  array $migrations
+     * @param  bool  $pretend
+     *
+     * @return void
+     */
+    public function runMigrationList($migrations, $pretend = false)
+    {
+        // First we will just make sure that there are any migrations to run. If there
+        // aren't, we will just make a note of it to the developer so they're aware
+        // that all of the migrations have been run against this database system.
+        if (count($migrations) == 0) {
+
+            $this->note("<info>Nothing to migrate: {$this->namespace}</info>");
+
+            return;
+        }
+
+        $batch = $this->repository->getNextBatchNumber();
+
+        // Once we have the array of migrations, we will spin through them and run the
+        // migrations "up" so the changes are made to the databases. We'll then log
+        // that the migration was run so we don't repeat it next time we execute.
+        foreach ($migrations as $file) {
+            $this->runUp($file, $batch, $pretend);
+        }
+    }
+
+    /**
+     * @param $file
+     */
+    protected function requireOnce($file)
+    {
+        $namespace = $this->getNamespaceFromMigrationFile($file);
+
+        $addonCollection = (new AddonCollection())->merged();
+
+        if ($addon = $addonCollection->get($namespace)) {
+
+            $path = $addon->getPath('migrations/') . $file . '.php';
+
+        } else {
+
+            $path = base_path('database/migrations/') . $file . '.php';
+        }
+
+        if (is_file($path)) {
+
+            $this->files->requireOnce($path);
+        }
+    }
+
+    /**
+     * Resolve a migration instance from a file.
+     *
+     * @param  string $file
+     *
+     * @return object
+     */
+    public function resolve($file)
+    {
+        $this->requireOnce($file);
+
+        return app($this->dispatch(new TransformMigrationNameToClass($this->removeDatePrefix($file))));
+    }
+
+    /**
+     * @param $file
+     *
+     * @return string
+     */
+    public function removeDatePrefix($file)
+    {
+        return implode('_', array_slice(explode('_', $file), 4));
+    }
+
+    /**
+     * @param $file
+     *
+     * @return string
+     */
+    public function getNamespaceFromMigrationFile($file)
+    {
+        $file = $this->removeDatePrefix($file);
+
+        $segments = explode('__', $file);
+
+        return $segments[0];
+    }
+
+    /**
+     * Rollback the last migration operation.
+     *
+     * @param       $namespace
+     * @param  bool $pretend
+     *
+     * @return int
+     */
+    public function rollbackNamespace($namespace, $pretend = false)
+    {
+        $this->notes = [];
+
+        // We want to pull in the last batch of migrations that ran on the previous
+        // migration operation. We'll then reverse those migrations and run each
+        // of them "down" to reverse the last migration "operation" which ran.
+        $migrations = $this->repository->findManyByNamespace($namespace);
+
+        if (count($migrations) == 0) {
+            $this->note("<info>Nothing to rollback: {$namespace}</info>");
+
+            return count($migrations);
+        }
+
+        // We need to reverse these migrations so that they are "downed" in reverse
+        // to what they run on "up". It lets us backtrack through the migrations
+        // and properly reverse the entire database schema operation that ran.
+        foreach ($migrations as $migration) {
+            $this->runDown((object) $migration, $pretend);
+        }
+
+        return count($migrations);
+    }
+
+}


### PR DESCRIPTION
## Addon Migration Examples

### Making an addon migration
`php artisan make:migration create_blogs_stream --addon=anomaly.module.blogs`

### Running all migrations for an addon
`php artisan migrate --addon=anomaly.module.blogs`

### Resetting all migrations for an addon
`php artisan migrate:reset --addon=anomaly.module.blogs`
