### PR TITLE
added some of render() methods to the view().

### DIFF
--- a/src/Addon/FieldType/FieldType.php
+++ b/src/Addon/FieldType/FieldType.php
@@ -659,11 +659,11 @@ class FieldType extends Addon
     /**
      * Render the input and wrapper.
      *
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function render()
     {
-        return view($this->getWrapperView(), ['field_type' => $this]);
+        return view($this->getWrapperView(), ['field_type' => $this])->render();
     }
 
     /**
@@ -857,21 +857,21 @@ class FieldType extends Addon
     /**
      * Render the input.
      *
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function renderInput()
     {
-        return view($this->getInputView(), ['field_type' => $this]);
+        return view($this->getInputView(), ['field_type' => $this])->render();
     }
 
     /**
      * Render the filter.
      *
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function renderFilter()
     {
-        return view($this->getFilterView(), ['field_type' => $this]);
+        return view($this->getFilterView(), ['field_type' => $this])->render();
     }
 
     /**


### PR DESCRIPTION
It will allow to render exceptions somehow. because Illumite/View::__toString() could not render exceptions.

Using this, I was able to debug to this:

```
An exception has been thrown during the rendering of a template ("An exception has been thrown during the rendering of a template ("An exception has been thrown during the rendering of a template ("array_reverse() expects parameter 1 to be array, string given") in "/home/huglester/Projects/app-pyro/core/anomaly/country-field_type/resources/views/input.twig" at line 3.") in "/home/huglester/Projects/app-pyro/vendor/anomaly/streams-platform/src/View/Command/../../../resources/views/form/partials/wrapper.twig" at line 24.") in "streams::form/partials/default" at line 13.
```
Instead of just "Illuminate/Viwe::_toSting could not render exceptions"

