### PR TITLE
Allow globbing of asset files

### DIFF
--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -120,6 +120,13 @@ class Asset
         if (starts_with($file, ['http', '//']) || file_exists($file) || is_dir(trim($file, '*'))) {
             $this->collections[$collection][$file] = $filters;
         }
+        // if none of the previous conditions were met then lets check and see if globbing the file
+        // will return any results
+        else if (count(glob($file)) > 0) {
+            foreach(glob($file) as $curFile) {
+                $this->collections[$collection][$curFile] = $filters;
+            }
+        }
 
         if (
             config('app.debug')


### PR DESCRIPTION
Granted asset_add can already glob a single directory using php glob function will allow for including nested directories, as well as any globbing magic that php allows. This might be able to replace the is_dir in the condition above it, but I was unsure if it would have any negative side effects by removing it from the line above.