### PR TITLE
Bug/fix tree children with intval on get parent

### DIFF
--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -182,11 +182,12 @@ class Asset
      *
      * @param       $collection
      * @param array $filters
+	 * @param array $attributes
      * @return string
      */
-    public function script($collection, array $filters = [])
+    public function script($collection, array $filters = [], array $attributes = [])
     {
-        return $this->html->script($this->path($collection, $filters));
+        return $this->html->script($this->path($collection, $filters), $attributes);
     }
 
     /**
@@ -194,11 +195,12 @@ class Asset
      *
      * @param       $collection
      * @param array $filters
+	 * @param array $attributes
      * @return string
      */
-    public function style($collection, array $filters = [])
+    public function style($collection, array $filters = [], array $attributes = [])
     {
-        return $this->html->style($this->path($collection, $filters));
+        return $this->html->style($this->path($collection, $filters), $attributes);
     }
 
     /**

--- a/src/Ui/Tree/Component/Item/Item.php
+++ b/src/Ui/Tree/Component/Item/Item.php
@@ -95,7 +95,7 @@ class Item implements ItemInterface
      */
     public function getParent()
     {
-        return $this->parent;
+        return intval($this->parent);
     }
 
     /**

--- a/src/Ui/Tree/Component/Item/ItemCollection.php
+++ b/src/Ui/Tree/Component/Item/ItemCollection.php
@@ -45,7 +45,7 @@ class ItemCollection extends Collection
 
         /* @var ItemInterface $item */
         foreach ($this->items as $item) {
-            if ($item->getParent() === $parent->getId()) {
+            if ($item->getParent() == $parent->getId()) {
                 $children[] = $item;
             }
         }


### PR DESCRIPTION
Use intval on Item class to ensure that the parent is actually an ID. The reason that the children weren't showing in the pages or navigation tree is because getParent was returning a string and comparing it to an int using ===