### PR TITLE
Fix tree children with intval on getParent method of Item class

### DIFF
--- a/src/Ui/Tree/Component/Item/Item.php
+++ b/src/Ui/Tree/Component/Item/Item.php
@@ -95,7 +95,7 @@ class Item implements ItemInterface
      */
     public function getParent()
     {
-        return $this->parent;
+        return intval($this->parent);
     }
 
     /**


### PR DESCRIPTION
Found the bug that was not showing children in the item tree. There will be this pull request and another. Choose one or the other, but really it would work if you accepted both of them. This one ensures that the getParent method of the item class is indeed an integer so that the === in the children function of ItemCollection will be true.