### PR TITLE
Fix tree children by using a non exact equality. == rather than ===

### DIFF
--- a/src/Ui/Tree/Component/Item/ItemCollection.php
+++ b/src/Ui/Tree/Component/Item/ItemCollection.php
@@ -45,7 +45,7 @@ class ItemCollection extends Collection
 
         /* @var ItemInterface $item */
         foreach ($this->items as $item) {
-            if ($item->getParent() === $parent->getId()) {
+            if ($item->getParent() == $parent->getId()) {
                 $children[] = $item;
             }
         }


### PR DESCRIPTION
Found the bug that was not showing children in the item tree. There will be this pull request and another. Choose one or the other, but really it would work if you accepted both of them. This one uses == rather than === so that the string "2" will equal the int(2) as is returned from the getParent function.