### PR TITLE
Use rawurlencode rather than urlencode

### DIFF
--- a/src/Support/Parser.php
+++ b/src/Support/Parser.php
@@ -102,7 +102,7 @@ class Parser
                 'route'   => [
                     'parameters'            => array_map(
                         function ($value) {
-                            return urlencode($value);
+                            return rawurlencode($value);
                         },
                         $route->parameters()
                     ),
@@ -110,7 +110,7 @@ class Parser
                         '/',
                         array_map(
                             function ($value) {
-                                return urlencode($value);
+                                return rawurlencode($value);
                             },
                             $route->parameters()
                         )


### PR DESCRIPTION
http://stackoverflow.com/questions/996139/urlencode-vs-rawurlencode

I was still having some issues creating sub folders of folders that had spaces. I was able to create " Main Content Images > Home Page > Test Folder > This is a test folder! > And another test folder > Last Test" using this function.