### PR TITLE
Fix ExceptionHandler for when 'app.debug' is false

### DIFF
--- a/src/Exception/ExceptionHandler.php
+++ b/src/Exception/ExceptionHandler.php
@@ -30,7 +30,7 @@ class ExceptionHandler extends Handler
         if ($this->isHttpException($e)) {
             return $this->renderHttpException($e);
         } elseif (!config('app.debug')) {
-            return response()>view("streams::errors.500", ['message' => $e->getMessage()], 500);
+            return response()->view("streams::errors.500", ['message' => $e->getMessage()], 500);
         } else {
             return parent::render($request, $e);
         }

--- a/src/Exception/ExceptionHandler.php
+++ b/src/Exception/ExceptionHandler.php
@@ -30,7 +30,7 @@ class ExceptionHandler extends Handler
         if ($this->isHttpException($e)) {
             return $this->renderHttpException($e);
         } elseif (!config('app.debug')) {
-            return response()->setStatusCode(500)->view("streams::errors.500", ['message' => $e->getMessage()]);
+            return response()>view("streams::errors.500", ['message' => $e->getMessage()], 500);
         } else {
             return parent::render($request, $e);
         }


### PR DESCRIPTION
The returned ResponseFactory from response() doesn't have a setStatusCode method. Use view($template, $vars, $statusCode) instead