### PR TITLE
Add missing symfony/yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "mobiledetect/mobiledetectlib": "2.8.*",
         "nicmart/string-template": "0.1.*",
         "barryvdh/laravel-httpcache": "0.2.*",
-        "phive/twig-extensions-deferred": "0.3.*"
+        "phive/twig-extensions-deferred": "0.3.*",
+        "symfony/yaml": "~2.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
Add dependency on symfony/yaml ~2.0, equivalent to the version used by phpunit. Yaml was only being pulled in by dev dependencies, therefore using composer's --no-dev left the project without it. 

Closes pyrocms/pyrocms#3550