### PR TITLE
Namespace not taken from migration file

### DIFF
--- a/src/Database/Migration/Command/Handler/MigrateAssignmentsHandler.php
+++ b/src/Database/Migration/Command/Handler/MigrateAssignmentsHandler.php
@@ -65,6 +65,7 @@ class MigrateAssignmentsHandler
 
         $stream = $migration->getStream();
         $fields = $migration->getAssignments();
+        $namespace = $migration->getNamespace();
 
         if (!$fields) {
             return;
@@ -74,7 +75,7 @@ class MigrateAssignmentsHandler
 
         $stream = $this->streams->findBySlugAndNamespace(
             array_get($stream, 'slug'),
-            array_get($stream, 'namespace', $addon->getSlug())
+            array_get($stream, 'namespace', $namespace ?: ($addon ? $addon->getSlug() : null))
         );
 
         foreach ($fields as $field => $assignment) {


### PR DESCRIPTION
Ensures that if namespace is defined in the migration file, then it's used over the namespace of the addon.