### PR TITLE
Set Form Entry before Options and Default Options

### DIFF
--- a/src/Ui/Form/Command/BuildForm.php
+++ b/src/Ui/Form/Command/BuildForm.php
@@ -56,10 +56,9 @@ class BuildForm implements SelfHandling
          */
         $this->dispatch(new SetFormModel($this->builder));
         $this->dispatch(new SetFormStream($this->builder));
-        $this->dispatch(new SetDefaultParameters($this->builder));
         $this->dispatch(new SetRepository($this->builder));
-
         $this->dispatch(new SetFormEntry($this->builder));
+        $this->dispatch(new SetDefaultParameters($this->builder));
         $this->dispatch(new SetFormOptions($this->builder));
         $this->dispatch(new SetDefaultOptions($this->builder));
 

--- a/src/Ui/Form/Command/BuildForm.php
+++ b/src/Ui/Form/Command/BuildForm.php
@@ -59,9 +59,9 @@ class BuildForm implements SelfHandling
         $this->dispatch(new SetDefaultParameters($this->builder));
         $this->dispatch(new SetRepository($this->builder));
 
+        $this->dispatch(new SetFormEntry($this->builder));
         $this->dispatch(new SetFormOptions($this->builder));
         $this->dispatch(new SetDefaultOptions($this->builder));
-        $this->dispatch(new SetFormEntry($this->builder)); // Do this last.
 
         /**
          * Before we go any further, authorize the request.


### PR DESCRIPTION
Setting the form entry before the setting the form options and default form options allows us to use the entry data in the form options. I.E. using the entry name (if it exists) in the form title.