### PR TITLE
Bug table options should accept strings

### DIFF
--- a/src/Ui/Table/TableBuilder.php
+++ b/src/Ui/Table/TableBuilder.php
@@ -445,9 +445,18 @@ class TableBuilder
      * @param array $options
      * @return $this
      */
-    public function setOptions(array $options)
+    public function setOptions($options)
     {
-        $this->options = array_merge($this->options, $options);
+        /**
+         * Options can be an options handler
+         */
+        if(is_string($options)) {
+            $this->options = $options;
+        }
+
+        if(is_array($this->options) && is_array($options)) {
+            $this->options = array_merge($this->options, $options);
+        }
 
         return $this;
     }


### PR DESCRIPTION
When an options handler is used it will be set as a string. setOptions needs to accept both strings and arrays.