### PR TITLE
Bug table options should accept strings

### DIFF
--- a/resources/views/table/partials/body.twig
+++ b/resources/views/table/partials/body.twig
@@ -1,6 +1,7 @@
 <tbody>
 {% for row in table.rows %}
-    <tr id="{{ loop.index }}">
+    {{ dump(table.options) }}
+    <tr id="{{ loop.index }}" class="{{ table.options.row_class(row.entry) }}">
 
         {% if table.options.sortable %}
             <td>

--- a/resources/views/table/partials/body.twig
+++ b/resources/views/table/partials/body.twig
@@ -1,6 +1,5 @@
 <tbody>
 {% for row in table.rows %}
-    {{ dump(table.options) }}
     <tr id="{{ loop.index }}" class="{{ table.options.row_class(row.entry) }}">
 
         {% if table.options.sortable %}

--- a/src/Ui/Table/TableBuilder.php
+++ b/src/Ui/Table/TableBuilder.php
@@ -447,27 +447,7 @@ class TableBuilder
      */
     public function setOptions($options)
     {
-        /**
-         * Options can be an options handler
-         */
-        if(is_string($options)) {
-            $this->options = $options;
-        }
-
-        /**
-         * If we are adding options then merge them
-         */
-        if(is_array($options) && is_array($this->options)) {
-            $this->options = array_merge($this->options, $options);
-        }
-
-        /**
-         * If we came from a string (handler) and are setting
-         * an options array, then overwrite
-         */
-        if(is_array($options) && !is_array($this->options)) {
-            $this->options = $options;
-        }
+        $this->options = $options;
 
         return $this;
     }

--- a/src/Ui/Table/TableBuilder.php
+++ b/src/Ui/Table/TableBuilder.php
@@ -454,8 +454,19 @@ class TableBuilder
             $this->options = $options;
         }
 
-        if(is_array($this->options) && is_array($options)) {
+        /**
+         * If we are adding options then merge them
+         */
+        if(is_array($options) && is_array($this->options)) {
             $this->options = array_merge($this->options, $options);
+        }
+
+        /**
+         * If we came from a string (handler) and are setting
+         * an options array, then overwrite
+         */
+        if(is_array($options) && !is_array($this->options)) {
+            $this->options = $options;
         }
 
         return $this;

--- a/src/Ui/Table/TableBuilder.php
+++ b/src/Ui/Table/TableBuilder.php
@@ -445,9 +445,18 @@ class TableBuilder
      * @param array $options
      * @return $this
      */
-    public function setOptions(array $options)
+    public function setOptions($options)
     {
-        $this->options = array_merge($this->options, $options);
+        /**
+         * Options can be an options handler
+         */
+        if(is_string($options)) {
+            $this->options = $options;
+        }
+
+        if(is_array($this->options) && is_array($options)) {
+            $this->options = array_merge($this->options, $options);
+        }
 
         return $this;
     }


### PR DESCRIPTION
Okay this one works all the time. We have to be able to come from a string handler and go to an options array, add just an options array, or merge options together to match the functionality from before.