### PR TITLE
Correctly count force deleted entries

### DIFF
--- a/src/Model/EloquentRepository.php
+++ b/src/Model/EloquentRepository.php
@@ -191,7 +191,10 @@ class EloquentRepository implements EloquentRepositoryInterface
     {
         $entry->forceDelete();
 
-        return true;
+        /**
+         * If we were not able to force delete
+         */
+        return !$entry->exists;
     }
 
     /**


### PR DESCRIPTION
Since the force delete can be caught and rejected by an observer, we should check that the entry was actually deleted rather than returning true.

I noticed this when I tried to force delete and entry, but rejected it due to another constraint, but the table still showed 1 row(s) successfully deleted.

![screen shot 2016-07-05 at 11 28 13 am](https://cloud.githubusercontent.com/assets/535135/16593663/99fcd020-42a3-11e6-8924-de10fbbb20fa.png)
