### PR TITLE
Image __toString should always return a string

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -1144,7 +1144,12 @@ class Image
      */
     public function __toString()
     {
-        return $this->output();
+        $output = $this->output();
+        if (is_string($output)) {
+            return $this->output();
+        }
+
+        return "";
     }
 
     /**

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -1144,8 +1144,7 @@ class Image
      */
     public function __toString()
     {
-        $output = $this->output();
-        return (is_string($output))? $output : "";
+        return (string) $this->output();
     }
 
     /**

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -1145,11 +1145,7 @@ class Image
     public function __toString()
     {
         $output = $this->output();
-        if (is_string($output)) {
-            return $this->output();
-        }
-
-        return "";
+        return (is_string($output))? $output : "";
     }
 
     /**


### PR DESCRIPTION
Even if there is no output (missing image or error) the image __toString should alwasy return a string.

I just got tired of missing or errored images throwing a 500. What do you think about just returning an empty string if the output isn't already a string?

    ErrorException: Method Anomaly\Streams\Platform\Image\Image::__toString() must return a string value in /var/www/app.findingtruth.io/public_html/vendor/twig/twig/lib/Twig/Extension/Core.php:968