### PR TITLE
Remove attr disabled on drag drop of table row

### DIFF
--- a/resources/js/table/sortable.js
+++ b/resources/js/table/sortable.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
         placeholder: '<tr class="placeholder"/>',
         afterMove: function ($placeholder) {
 
-            $placeholder.closest('table').find('button.reorder').removeClass('disabled');
+            $placeholder.closest('table').find('button.reorder').removeClass('disabled').removeAttr('disabled');
 
             $placeholder.closest('table').find('.dragged').detach().insertBefore($placeholder);
         }


### PR DESCRIPTION
We also have to remove the attr disabled on the table button when a row is dragged and dropped otherwise the button will still not be clickable, but will required a checkbox to be checked to enable the reorder button.