### PR TITLE
Exception handler errors out!

### DIFF
--- a/src/Exception/ExceptionHandler.php
+++ b/src/Exception/ExceptionHandler.php
@@ -57,7 +57,7 @@ class ExceptionHandler extends \Illuminate\Foundation\Exceptions\Handler
         if (!config('app.debug') && view()->exists("streams::errors.{$status}")) {
             return response()->view("streams::errors.{$status}", ['message' => $e->getMessage()], $status);
         } else {
-            return (new SymfonyDisplayer(config('app.debug')))->createResponse($e);
+            return (new SymfonyDisplayer(config('app.debug')))->handle($e);
         }
     }
 }


### PR DESCRIPTION
```
FatalThrowableError in ExceptionHandler.php line 61:
Call to undefined method Symfony\Component\Debug\ExceptionHandler::createResponse()
```

Method `createResponse`  was replaced with `handle`, this should work now,

Wasn't going to PR this, they should allow comments, 