### PR TITLE
Maybe use App\Http\Middleware\VerifyCsrfToken?

### DIFF
--- a/src/Http/Controller/BaseController.php
+++ b/src/Http/Controller/BaseController.php
@@ -131,7 +131,7 @@ class BaseController extends Controller
         }
 
         // These may be manipulated by the middleware above.
-        $this->middleware('Illuminate\Foundation\Http\Middleware\VerifyCsrfToken');
+        $this->middleware('App\Http\Middleware\VerifyCsrfToken');
         $this->middleware('Anomaly\Streams\Platform\Http\Middleware\ApplicationReady');
         $this->middleware('Anomaly\Streams\Platform\Http\Middleware\SetLocale');
         $this->middleware('Anomaly\Streams\Platform\Http\Middleware\PoweredBy');


### PR DESCRIPTION
Hello,
maybe better to use: $this->middleware('App\Http\Middleware\VerifyCsrfToken'); for easier extendability?
I know we can override via IOC, but this is more 'laravel' intuitive? Just my two cents :)

You would need to override $except = [] often