### PR TITLE
Bind site description to 'app.description'

### DIFF
--- a/resources/config/settings/settings.php
+++ b/resources/config/settings/settings.php
@@ -17,6 +17,7 @@ return [
     ],
     'description'     => [
         'type'   => 'anomaly.field_type.text',
+        'bind'   => 'app.description',
         'config' => [
             'default_value' => function (Repository $config) {
                 return $config->get('streams::distribution.description');


### PR DESCRIPTION
The description field wasnt accessible at the same level as `app.name` was via `config_get('app.name')`.
I thought it made sense that at least the site description should be accessible via `config_get('app.description')`.

This change is required for a subsequent PR I'm making to alter the `rss.xml` template.