### PR TITLE
nullable rule and required_* rules

### DIFF
--- a/src/Ui/Form/Component/Field/Guesser/NullableGuesser.php
+++ b/src/Ui/Form/Component/Field/Guesser/NullableGuesser.php
@@ -22,6 +22,14 @@ class NullableGuesser
                 continue;
             }
 
+            // If the field depends on other fields, we not add nullable here
+            // because validation will not be performed at all on this field
+            if (! empty($field['rules'])) {
+                if (preg_grep("/required_.*/", $field['rules'])) {
+                    continue;
+                }
+            }
+
             // If not required then nullable.
             if (isset($field['required']) && $field['required'] == false) {
                 $field['rules'][] = 'nullable';


### PR DESCRIPTION
without this, validation with required_with:field1,field2 etc would look like:
"as_company" => "nullable"
  "company_name" => "required_with:as_company|nullable"
  "company_code" => "required_with:as_company|nullable"

so basicly it would allow comapany_name EMPTY while 'as_company' would be checked.