### PR TITLE
Replaced logical operators

### DIFF
--- a/src/Support/Decorator.php
+++ b/src/Support/Decorator.php
@@ -25,7 +25,7 @@ class Decorator extends \Robbo\Presenter\Decorator
             return $value->getObject();
         }
 
-        if (is_array($value) or ($value instanceof IteratorAggregate and $value instanceof ArrayAccess)) {
+        if (is_array($value) || ($value instanceof IteratorAggregate && $value instanceof ArrayAccess)) {
             foreach ($value as $k => $v) {
                 $value[$k] = $this->undecorate($v);
             }


### PR DESCRIPTION
Hi. I spotted couple of logical operators (namely, ```or``` and ```and```) in the source code. 

The problem with these operators is that they do not have the same precedence as ```||``` and ```&&```. This could lead to unexpected behavior. 

This issue has now been amended.

Thank you. 