### PR TITLE
Fix pgsql driver slug

### DIFF
--- a/src/Installer/Console/Command/SetDatabaseData.php
+++ b/src/Installer/Console/Command/SetDatabaseData.php
@@ -48,10 +48,10 @@ class SetDatabaseData
         $this->data->put(
             'DB_DRIVER',
             $this->command->askWithCompletion(
-                'What database driver would you like to use? [mysql, postgres, sqlite, sqlsrv]',
+                'What database driver would you like to use? [mysql, pgsql, sqlite, sqlsrv]',
                 [
                     'mysql',
-                    'postgres',
+                    'pgsql',
                     'sqlite',
                     'sqlsrv',
                 ],


### PR DESCRIPTION
In ConfigureDatabase.php file you've used this command to configure DB:
```php
require base_path('config/database.php')
```
But there is'n `postgres` driver in `database.php` in Laravel's config, there is only `pgsql`