### PR TITLE
Allowing views to be overridden globally

### DIFF
--- a/src/View/ViewComposer.php
+++ b/src/View/ViewComposer.php
@@ -164,6 +164,8 @@ class ViewComposer
                 $view->setPath($path);
             } elseif ($path = array_get($overrides, $view->getName(), null)) {
                 $view->setPath($path);
+            } elseif ($path = array_get(config('streams.overrides'), $view->getName(), null)) {
+                $view->setPath($path);
             }
         }
 


### PR DESCRIPTION
The actual PR is the first commit. 

In config\streams.php add overrides like:
```
    'overrides' => [
        'streams::form.partials.heading'  => 'overrides/form-partials-heading',
        'streams::form.form'              => 'overrides/form-form',
        'streams::form.partials.wrapper'  => 'overrides/form-partials-wrapper',
        'streams::form.partials.controls' => 'overrides/form-partials-controls',
    ]
```

The second commit is a proposal, I am getting at about 20 (seen up to 40) cache hits per page load.

I've been using both commits more than for one month (in production)