### PR TITLE
Added missing exception handling in Kernel.php

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -103,6 +103,11 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
          * Check the domain for a locale.
          */
         $url  = parse_url(array_get($_SERVER, 'HTTP_HOST'));
+
+        if ($url === false) {
+          throw new \Exception('Malformed URL: ' . $url);
+        }
+
         $host = array_get($url, 'host');
 
         $pattern = '/^(' . implode('|', array_keys($locales['supported'])) . ')(\.)./';


### PR DESCRIPTION
Hi.

Looks like there was a bit risky use of ```parse_url``` function in src/Http/Kernel.php. 

Basically: parse_url can return boolean false if the URL is malformed. Should this happen, the hackers will be able to pass seriously malformed URLs to perform hostile XSS injections. 

I created an if-clause for malformed URLs. Basically, if variable ```$url``` gets malformed URL which makes the parse_url to return false, the Kernel.php throws an exception. 

Thank you.