### PR TITLE
Allow forms to persist between submits in case there are any errors.

### DIFF
--- a/src/Http/Controller/FormController.php
+++ b/src/Http/Controller/FormController.php
@@ -40,7 +40,10 @@ class FormController extends PublicController
             ->getFormResponse();
 
         $builder->flash();
-        $cache->forget('form::' . $key);
+
+        if(!$builder->hasFormErrors()) {
+            $cache->forget('form::' . $key);
+        }
 
         if ($response && $response->getStatusCode() !== 200) {
             return $response;

--- a/src/Ui/Form/Command/ValidateForm.php
+++ b/src/Ui/Form/Command/ValidateForm.php
@@ -39,6 +39,13 @@ class ValidateForm
     {
         $validator = $this->builder->getValidator();
 
+        /**
+         * Since we are about to validate the form we can
+         * ignore any errors what were previously set in
+         * the session.
+         */
+        $this->builder->getForm()->resetErrors();
+
         /*
          * If it's self handling just add @handle
          */

--- a/src/Ui/Form/Form.php
+++ b/src/Ui/Form/Form.php
@@ -205,6 +205,18 @@ class Form implements PresentableInterface
     }
 
     /**
+     * Reset any errors that might exist on this form.
+     *
+     * @return $this
+     */
+    public function resetErrors()
+    {
+        $this->errors = new MessageBag();
+
+        return $this;
+    }
+
+    /**
      * Return whether the form has errors or not.
      *
      * @return bool


### PR DESCRIPTION
We do this by not forgetting the cache unless the builder was submitted
without errors.

This introduced another issue. Where the errors were being applied to
the form again via the session. To solve this I reset the form errors
when the form is being validated. This allows the old errors to be
forgotten and the new errors to persist through.