### PR TITLE
Replaced non-existend method in EloquentRepository.php

### DIFF
--- a/src/Model/EloquentRepository.php
+++ b/src/Model/EloquentRepository.php
@@ -63,7 +63,7 @@ class EloquentRepository implements EloquentRepositoryInterface
     public function findTrashed($id)
     {
         return $this->model
-            ->onlyTrashed()
+            ->trashed()
             ->orderBy('id', 'ASC')
             ->where('id', $id)
             ->first();


### PR DESCRIPTION
Hi.

Method ```findTrashed``` was calling ```onlyTrashed``` method in EloquentModel. How ever, this method does not exist. 

I've replaced this method call with the correct one. 

Thank you.