### PR TITLE
Added merge skips to FormBuilder

### DIFF
--- a/src/Ui/Form/FormBuilder.php
+++ b/src/Ui/Form/FormBuilder.php
@@ -535,6 +535,18 @@ class FormBuilder
     }
 
     /**
+     * Merge in skips.
+     *
+     * @param  array|string $skips
+     * @return $this
+     */
+    public function mergeSkips($skips) {
+        $this->skips = array_merge($this->getSkips(), $skips);
+
+        return $this;
+    }
+
+    /**
      * Add a skipped field.
      *
      * @param $fieldSlug


### PR DESCRIPTION
Used exactly like `mergeOptions`:

```php
$builder->mergeSkips(['field_1', 'field_2]);
```