### PR TITLE
Fixed a bug with the field filler removing the first field

### DIFF
--- a/src/Ui/Form/Component/Field/FieldFiller.php
+++ b/src/Ui/Form/Component/Field/FieldFiller.php
@@ -52,7 +52,13 @@ class FieldFiller
                 continue;
             }
 
-            unset($fill[array_search($parameters['field'], $fill)]);
+            $search = array_search($parameters['field'], $fill);
+
+            // Make sure it actually found something before unsetting
+            if ($search != false) {
+                unset($fill[$search]);
+            }
+
         }
 
         /*


### PR DESCRIPTION
This happens if you set the fields for a form builder like this:

```php

$builder->setFields([
  '*',
  'other_field' => 'anomaly.field_type.text'
]);

```

And where the form builder has a stream entry with some fields like this:

```php
$fields = [
  'title',
  'slug' => [
    'config' => [
      'slugify' => 'title'
    ]
  ]
];
```



When the `FieldFiller` loops over the fields, it's not checking to make sure the `array_search` actually returns something (and not `false`), so I added a check to make sure that it doesn't return false. Otherwise the first field will get removed (title).