### PR TITLE
Added throws exception on errors in composer.json

### DIFF
--- a/src/Addon/AddonLoader.php
+++ b/src/Addon/AddonLoader.php
@@ -54,7 +54,7 @@ class AddonLoader
         }
 
         if (!$composer = json_decode(file_get_contents($path . '/composer.json'), true)) {
-            throw new \Exception("You have an error in composer.json syntax in {$path}/composer.json file", 1);
+            throw new \Exception("You have an error in JSON syntax in {$path}/composer.json file");
         };
 
         if (!array_key_exists('autoload', $composer)) {

--- a/src/Addon/AddonLoader.php
+++ b/src/Addon/AddonLoader.php
@@ -53,7 +53,9 @@ class AddonLoader
             return;
         }
 
-        $composer = json_decode(file_get_contents($path . '/composer.json'), true);
+        if (!$composer = json_decode(file_get_contents($path . '/composer.json'), true)) {
+            throw new \Exception("You have an error in composer.json syntax in {$path}/composer.json file", 1);
+        };
 
         if (!array_key_exists('autoload', $composer)) {
             return;


### PR DESCRIPTION
When you have typo in one of your addons composer.json files, there was an exception like that, before:
```term
                                                                  
  [ErrorException]                                                
  array_key_exists() expects parameter 2 to be array, null given  

```
I want to add like this:
```terminal
                                                                                                                                          
  [Exception]                                                                                                                             
  You have an error in composer.json syntax in /{APP_PATH}/core/anomaly/default_page_handler-extension/composer.json file

```