### PR TITLE
fix currency_format

### DIFF
--- a/src/Support/Currency.php
+++ b/src/Support/Currency.php
@@ -71,7 +71,7 @@ class Currency
             $suffix = $this->symbol($currency);
         }
 
-        return $prefix . number_format(floor(($number * 100)) / 100, $decimals, $point, $separator) . $suffix;
+        return $prefix . number_format($number, $decimals, $point, $separator) . $suffix;
     }
 
     /**


### PR DESCRIPTION
With old formating in place, you will have ambigous numbers.
not sure why it is needed at all here.

we format value, add prefix/suffix and thats it!

thanks