### PR TITLE
Rows (when using columns) doesn't have the correct styles

### DIFF
--- a/resources/views/form/partials/rows.twig
+++ b/resources/views/form/partials/rows.twig
@@ -1,11 +1,13 @@
 {% for row in rows %}
-    <div class="row">
-        {% for column in row.columns %}
-            <div class="{{ column.classes ? column.classes|join(' ') : 'col-lg-' ~ column.size }}">
+    <div class="field-group">
+        <div class="row">
+            {% for column in row.columns %}
+                <div class="{{ column.classes ? column.classes|join(' ') : 'col-lg-' ~ column.size }}">
 
-                {% include "streams::form/partials/fields" with {"fields": column.fields} %}
+                    {% include "streams::form/partials/fields" with {"fields": column.fields} %}
 
-            </div>
-        {% endfor %}
+                </div>
+            {% endfor %}
+        </div>
     </div>
 {% endfor %}


### PR DESCRIPTION
Wrapping the rows in an additional .field-group pulls in the correct styles for the rows.

I'm also pushing into master since develop doesn't have the rows form file.

Before:

![screen shot 2017-02-10 at 12 49 15 pm](https://cloud.githubusercontent.com/assets/535135/22841572/5ab61428-ef8f-11e6-8f1d-cb8321324d3f.png)

After:

![screen shot 2017-02-10 at 12 49 36 pm](https://cloud.githubusercontent.com/assets/535135/22841583/6699a9ee-ef8f-11e6-984f-711d4e81875a.png)
