### PR TITLE
Give more helpfull error when field not existing

### DIFF
--- a/src/Ui/Table/Component/Filter/Type/FieldFilter.php
+++ b/src/Ui/Table/Component/Filter/Type/FieldFilter.php
@@ -28,7 +28,12 @@ class FieldFilter extends Filter implements FieldFilterInterface
      */
     public function getInput()
     {
-        $field = $this->stream->getField($this->getField());
+        if (! $field = $this->stream->getField($this->getField())) {
+            throw new \Exception(sprintf(
+                'Field type: "%s" not found.',
+                $this->getField()
+            ));
+        }
 
         $type = $field->getType();
 


### PR DESCRIPTION
Hello,

I had this in migrations:
```php
'is_hidden' => [
            'type' => 'boolean',
        ],
```
after some time, this field type was just not found. I remember it happening in other module also.

Thanks!