### PR TITLE
[BUG] Exception handler returning null instead of Response object for HTTPExceptions.

### DIFF
--- a/src/Exception/ExceptionHandler.php
+++ b/src/Exception/ExceptionHandler.php
@@ -87,7 +87,7 @@ class ExceptionHandler extends NewExceptionHandler
         if (!config('app.debug') && view()->exists("streams::errors.{$status}")) {
             return response()->view("streams::errors.{$status}", ['message' => $e->getMessage()], $status);
         } else {
-            return (new SymfonyDisplayer(config('app.debug')))->handle($e);
+            return $this->convertExceptionToResponse($e);
         }
     }
 


### PR DESCRIPTION
I ran into an issue with the latest version of Pyro where, with debug mode enabled and the system in Maintenance Mode, visiting the site as a non-logged in user would yield a Whoops error complaining about an E_NOTICE instead of the expected 503, as you can see from the attached screenshot. ![pyro](https://cloud.githubusercontent.com/assets/1475492/23105170/68196daa-f6d2-11e6-99b9-ef8a0f2e8a0e.png)

I tracked the issue down to the fact that the ExceptionHandler is currently just instantiating a new SymfonyDisplayer and calling handle on that, but it looks like that method returns null and just sets the output, so the next Middleware that runs and expects a valid Reponse ends up being handed an invalid value instead.  Laravel itself avoid this problem by calling [convertExceptionToResponse](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Exceptions/Handler.php#L234) to ensure a Response object is returned using the correct response formatter, so I've attached a pull request to update Pyro's handler to do the same.  I know you're actually using a third party handler under the hood that extends Laravel's own handler before adding your own extensions on, but it all seems compatible in testing, so hopefully it should do the trick and avoid this edge case issue.

