### PR TITLE
Fix locale for 404/500 error pages

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
         \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \Anomaly\Streams\Platform\Http\Middleware\SetLocale::class,
     ];
 
     /**


### PR DESCRIPTION
This fixes 404 pages giving an internal server error due to incorrect locale.
Before the SetLocale middleware isn't injected until the BaseController. However, on 404 pages the BaseController is never reached. Move the SetLocale middle to the global middleware stack fixes this.