### PR TITLE
Allow field groups to be targeted with javascript

### DIFF
--- a/resources/views/form/partials/fields.twig
+++ b/resources/views/form/partials/fields.twig
@@ -1,5 +1,5 @@
 {% for field in fields %}
-    <div class="field-group">
+    <div class="field-group {{ field }}">
         {% for field in form.fields.translations(field) %}
             {{ field.render({'form': form})|raw }}
         {% endfor %}


### PR DESCRIPTION
Add field slug to field-group class just like we have in form-group.  Allows it to be targeted by JS