### PR TITLE
Event priority overwritten.

### DIFF
--- a/src/Addon/AddonProvider.php
+++ b/src/Addon/AddonProvider.php
@@ -286,8 +286,8 @@ class AddonProvider
         foreach ($listen as $event => $listeners) {
             foreach ($listeners as $key => $listener) {
                 if (is_integer($listener)) {
-                    $listener = $key;
                     $priority = $listener;
+                    $listener = $key;              
                 } else {
                     $priority = 0;
                 }


### PR DESCRIPTION
Value of $listener was being overwritten before being set to $priority.