### PR TITLE
Override json response values with any custom response sent by form h…

### DIFF
--- a/src/Ui/Form/Command/SetJsonResponse.php
+++ b/src/Ui/Form/Command/SetJsonResponse.php
@@ -42,12 +42,11 @@ class SetJsonResponse
     public function handle(ResponseFactory $response, ActionResponder $responder)
     {
         $data = new Collection();
+        $original = $this->builder->getFormResponse();
 
         if ($action = $this->builder->getActiveFormAction()) {
 
             $responder->setFormResponse($this->builder, $action);
-
-            $original = $this->builder->getFormResponse();
 
             if ($original instanceof RedirectResponse) {
                 $data->put('redirect', $original->getTargetUrl());
@@ -56,6 +55,12 @@ class SetJsonResponse
 
         $data->put('success', !$this->builder->hasFormErrors());
         $data->put('errors', $this->builder->getFormErrors()->toArray());
+        
+        if ($original && !$original instanceof RedirectResponse) {
+            foreach ($original->getData() as $key => $val) {
+                $data->put($key, $val);
+            }
+        }
 
         $this->builder->setFormResponse(
             $response = $response->json($data)


### PR DESCRIPTION
…andler

AJAX Forms return one of 3 responses.  Null, Redirect, or a custom response
If we have a custom response (ie not null and not a redirect) override data with the custom response values.  This allows developers to pass back custom AJAX responses via their form handlers while still allowing defaults to flow through from the existing logic.