### PR TITLE
null check on migrator

### DIFF
--- a/src/Database/Migration/MigrationRepository.php
+++ b/src/Database/Migration/MigrationRepository.php
@@ -26,7 +26,7 @@ class MigrationRepository extends DatabaseMigrationRepository
      */
     public function getRan($namespace = null)
     {
-        if ($addon = $this->migrator->getAddon()) {
+        if ($this->migrator !== null && $addon = $this->migrator->getAddon()) {
             return $this->table()
                 ->orderBy('batch', 'asc')
                 ->orderBy('migration', 'asc')


### PR DESCRIPTION
check if migrator is null, and handle it correctly
fixes #391 
note: the fix was testen in an local vagrant box, but copy/pasted into the github editor