### PR TITLE
Return void for all EntryObserver events

### DIFF
--- a/src/Entry/EntryObserver.php
+++ b/src/Entry/EntryObserver.php
@@ -94,8 +94,6 @@ class EntryObserver extends Observer
         //$entry->fireFieldTypeEvents('entry_saving');
 
         $this->commands->dispatch(new SetMetaInformation($entry));
-
-        return true;
     }
 
     /**
@@ -120,8 +118,6 @@ class EntryObserver extends Observer
     public function deleting(EntryInterface $entry)
     {
         $this->dispatch(new CascadeDelete($entry));
-
-        return true;
     }
 
     /**

--- a/src/Entry/EntryObserver.php
+++ b/src/Entry/EntryObserver.php
@@ -87,7 +87,6 @@ class EntryObserver extends Observer
      * meta information.
      *
      * @param  EntryInterface $entry
-     * @return bool
      */
     public function saving(EntryInterface $entry)
     {
@@ -113,7 +112,6 @@ class EntryObserver extends Observer
      * Run before a record is deleted.
      *
      * @param  EntryInterface|EloquentModel $entry
-     * @return bool
      */
     public function deleting(EntryInterface $entry)
     {


### PR DESCRIPTION
Returning a non-void value was causing issues with venturecraft/revisionable and is unneeded for any Pyro functionality.