### PR TITLE
StreamModel config data corrupted by Builder and EntryStreamParser.

### DIFF
--- a/src/Entry/Parser/EntryStreamParser.php
+++ b/src/Entry/Parser/EntryStreamParser.php
@@ -44,7 +44,7 @@ class EntryStreamParser
     {
         foreach ($stream->getAttributes() as $key => $value) {
             if (is_string($value)) {
-                $value = addslashes($value);
+                $value = addcslashes($value, "'");
             }
 
             $string .= "\n'{$key}' => '{$value}',";

--- a/src/Stream/StreamModel.php
+++ b/src/Stream/StreamModel.php
@@ -104,7 +104,9 @@ class StreamModel extends EloquentModel implements StreamInterface, PresentableI
         $streamModel        = new StreamModel();
         $streamTranslations = new EloquentCollection();
 
-        $data['config'] = serialize(array_get($data, 'config', []));
+        if (!is_string(array_get($data, 'config'))) {
+            $data['config'] = serialize(array_get($data, 'config', []));
+        }
 
         if ($translations = array_pull($data, 'translations')) {
             foreach ($translations as $attributes) {


### PR DESCRIPTION
- Removes unnecessary slashes for double quotes which are corrupting serialized data.
- Checks if $data['config'] is already a string before re-serializing it.

See [StreamModel config data corrupted by Builder and EntryStreamParser #4373](https://github.com/pyrocms/pyrocms/issues/4373)