### PR TITLE
[Streams-Platform] Skip empty lines from .env files #4406

### DIFF
--- a/src/Application/Command/LoadEnvironmentOverrides.php
+++ b/src/Application/Command/LoadEnvironmentOverrides.php
@@ -23,7 +23,7 @@ class LoadEnvironmentOverrides
             return;
         }
 
-        foreach (file($file, FILE_IGNORE_NEW_LINES) as $line) {
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
 
             // Check for # comments.
             if (!starts_with($line, '#')) {

--- a/src/Application/Command/ReloadEnvironmentFile.php
+++ b/src/Application/Command/ReloadEnvironmentFile.php
@@ -17,7 +17,7 @@ class ReloadEnvironmentFile
      */
     public function handle()
     {
-        foreach (file(base_path('.env'), FILE_IGNORE_NEW_LINES) as $line) {
+        foreach (file(base_path('.env'), FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
 
             // Check for # comments.
             if (!starts_with($line, '#')) {


### PR DESCRIPTION
 - Added FILE_SKIP_EMPTY_LINES flag when loading .env file