### PR TITLE
Fixed incorrect routes writing

### DIFF
--- a/src/Stream/Console/Command/AppendEntityRoutes.php
+++ b/src/Stream/Console/Command/AppendEntityRoutes.php
@@ -67,7 +67,7 @@ class AppendEntityRoutes
 
         $streams = count($files->glob($this->addon->getPath("migrations/*_stream.php")));
 
-        $segment    = (count($streams) > 1) ? "/{$this->slug}" : '';
+        $segment    = (count($streams) >= 1) ? "/{$this->slug}" : '';
         $prefix     = "{$vendor}\\{$slug}{$type}";
         $controller = "{$prefix}\\Http\\Controller\\Admin\\{$suffix}Controller";
 


### PR DESCRIPTION
Found the bug: when I had created second stream, it writes routes without stream slug, like it should be for the first.
This fixes it ^