### PR TITLE
[1.2] - Respond JSON if the client wants JSON in AuthenticationException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor
+/bin
+composer.lock

--- a/src/Exception/ExceptionHandler.php
+++ b/src/Exception/ExceptionHandler.php
@@ -1,10 +1,10 @@
 <?php namespace Anomaly\Streams\Platform\Exception;
 
 use Exception;
-use GrahamCampbell\Exceptions\NewExceptionHandler;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Auth\AuthenticationException;
+use GrahamCampbell\Exceptions\NewExceptionHandler;
 
 /**
  * Class ExceptionHandler
@@ -39,18 +39,9 @@ class ExceptionHandler extends NewExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        /**
-         * Have to catch this for some reason.
-         * Not sure why our handler passes this.
-         *
-         * @todo: Clean up
-         */
+
         if ($e instanceof AuthenticationException) {
-            if ($request->segment(1) === 'admin') {
-                return redirect()->guest('admin/login');
-            } else {
-                return redirect()->guest('login');
-            }
+            return $this->unauthenticated($request, $e);
         }
 
         return parent::render($request, $e);


### PR DESCRIPTION
Use case: 

Installed the API module, wrote a test for a protected endpoint, once the request gets to the Middleware an AuthenticationException is thrown and a 302 status code is sent with a redirection to the login page even is the client asked for JSON. 

![captura de pantalla 2017-07-05 a la s 4 02 21 p m](https://user-images.githubusercontent.com/2046653/27885395-846afc86-619d-11e7-8cf0-81e279ec908c.png)
![captura de pantalla 2017-07-05 a la s 4 03 45 p m](https://user-images.githubusercontent.com/2046653/27885394-8464df36-619d-11e7-9355-34523e605a49.png)

This PR will check if the client asked for JSON and if that is the case it will respond with JSON instead of the redirection

![captura de pantalla 2017-07-05 a la s 4 05 49 p m](https://user-images.githubusercontent.com/2046653/27885424-a11a92ba-619d-11e7-85ee-e99c05a146da.png)
![captura de pantalla 2017-07-05 a la s 4 06 07 p m](https://user-images.githubusercontent.com/2046653/27885425-a12142d6-619d-11e7-977d-533065c70353.png)
