### PR TITLE
Update EloquentTreeRepository.php

### DIFF
--- a/src/Model/EloquentTreeRepository.php
+++ b/src/Model/EloquentTreeRepository.php
@@ -99,13 +99,12 @@ class EloquentTreeRepository implements TreeRepositoryInterface
 
         foreach ($items as $index => $item) {
 
-            /* @var EloquentModel $entry */
-            $entry = $model->find($item['id']);
-
-            $entry->{$builder->getTreeOption('sort_column', 'sort_order')}  = $index + 1;
-            $entry->{$builder->getTreeOption('parent_column', 'parent_id')} = $parent;
-
-            $entry->save();
+            $model
+                ->where('id', $item['id'])
+                ->update([
+                    $builder->getTreeOption('sort_column', 'sort_order') => $index + 1,
+                    $builder->getTreeOption('parent_column', 'parent_id') => $parent
+                ]);
 
             if (isset($item['children'])) {
                 $this->save($builder, $item['children'], $item['id']);


### PR DESCRIPTION
Fix long delay and memory limit issues related to sorting large trees.  Simple mass update in a loop.  Tested against a huge data set.  Finishes in 1.1 sec vs 10 sec.  If this routine is used only for sorting trees then it's been tested and is safe to merge.