### PR TITLE
Revert mass update

### DIFF
--- a/src/Model/EloquentTreeRepository.php
+++ b/src/Model/EloquentTreeRepository.php
@@ -99,12 +99,11 @@ class EloquentTreeRepository implements TreeRepositoryInterface
 
         foreach ($items as $index => $item) {
 
-            $model
-                ->where('id', $item['id'])
-                ->update([
-                    $builder->getTreeOption('sort_column', 'sort_order') => $index + 1,
-                    $builder->getTreeOption('parent_column', 'parent_id') => $parent
-                ]);
+            /* @var EloquentModel $entry */
+            $entry = $model->find($item['id']);
+            $entry->{$builder->getTreeOption('sort_column', 'sort_order')}  = $index + 1;
+            $entry->{$builder->getTreeOption('parent_column', 'parent_id')} = $parent;
+            $entry->save();
 
             if (isset($item['children'])) {
                 $this->save($builder, $item['children'], $item['id']);


### PR DESCRIPTION
The mass update we committed was fast but bypasses all observers.  This in turn breaks the pages module, navigation module and perhaps a lot of custom code out in the wild.  Should be reverted.