### PR TITLE
Add polyfill for L5.4 UrlGenerator formatScheme method

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -170,4 +170,22 @@ class UrlGenerator extends \Illuminate\Routing\UrlGenerator
     {
         return (bool)$this->routes->getByName($name);
     }
+
+    /**
+     * Get the default scheme for a raw URL.
+     * This method is a polyfill for the same method in > Laravel 5.4 UrlGenerator.
+     *
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function formatScheme($secure)
+    {
+        if (! is_null($secure)) {
+            return $secure ? 'https://' : 'http://';
+        }
+        if (is_null($this->cachedSchema)) {
+            $this->cachedSchema = $this->forceScheme ?: $this->getScheme().'://';
+        }
+        return $this->cachedSchema;
+    }
 }

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -180,12 +180,12 @@ class UrlGenerator extends \Illuminate\Routing\UrlGenerator
      */
     public function formatScheme($secure)
     {
-        if (! is_null($secure)) {
+        if (!is_null($secure))
             return $secure ? 'https://' : 'http://';
-        }
-        if (is_null($this->cachedSchema)) {
+
+        if (is_null($this->cachedSchema))
             $this->cachedSchema = $this->forceScheme ?: $this->getScheme().'://';
-        }
+
         return $this->cachedSchema;
     }
 }


### PR DESCRIPTION
Adds a polyfill for the L5.4 `formatScheme` method which has been utilised in the latest commits to the Url Field Type. See issue here: https://github.com/pyrocms/pyrocms/issues/4537 and previous PR directly on FT here https://github.com/anomalylabs/url-field_type/pull/10