### PR TITLE
Adjusted the IF statement to require the .version() and config to be true

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -577,7 +577,7 @@ class Image
             return $this->config->get('app.debug', false) ? $e->getMessage() : null;
         }
 
-        if ($this->config->get('streams::images.version') || $this->getVersion() == true) {
+	    if ($this->config->get('streams::images.version') && (is_null($this->getVersion()) || $this->getVersion() == true)) {
             $path .= '?v=' . filemtime(public_path(trim($path, '/\\')));
         }
 

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -577,7 +577,7 @@ class Image
             return $this->config->get('app.debug', false) ? $e->getMessage() : null;
         }
 
-	    if ($this->config->get('streams::images.version') && (is_null($this->getVersion()) || $this->getVersion() == true)) {
+        if ($this->config->get('streams::images.version') && $this->getVersion() !== false) {
             $path .= '?v=' . filemtime(public_path(trim($path, '/\\')));
         }
 


### PR DESCRIPTION
If the config and `.version()` doesn't exist, or is true, then version the image. Otherwise, don't version the image.