### PR TITLE
Replace TestTheme instance assertions

### DIFF
--- a/tests/Unit/Addon/Theme/ThemeCollectionTest.php
+++ b/tests/Unit/Addon/Theme/ThemeCollectionTest.php
@@ -7,21 +7,24 @@ class ThemeCollectionTest extends TestCase
     {
         $collection = $this->app->make(\Anomaly\Streams\Platform\Addon\Theme\ThemeCollection::class);
 
-        $this->assertInstanceOf(Anomaly\TestAdminTheme\TestAdminTheme::class, $collection->active('admin'));
+        $this->assertInstanceOf(Anomaly\Streams\Platform\Addon\Theme\Theme::class, $collection->active('admin'));
+        $this->assertTrue($collection->active('admin')->isAdmin());
     }
 
     public function testCanReturnActiveStandardTheme()
     {
         $collection = $this->app->make(\Anomaly\Streams\Platform\Addon\Theme\ThemeCollection::class);
 
-        $this->assertInstanceOf(Anomaly\TestStandardTheme\TestStandardTheme::class, $collection->active('standard'));
+        $this->assertInstanceOf(Anomaly\Streams\Platform\Addon\Theme\Theme::class, $collection->active('standard'));
+        $this->assertFalse($collection->active('standard')->isAdmin());
     }
 
     public function testReturnsActiveCurrentByDefault()
     {
         $collection = $this->app->make(\Anomaly\Streams\Platform\Addon\Theme\ThemeCollection::class);
 
-        $this->assertInstanceOf(Anomaly\TestStandardTheme\TestStandardTheme::class, $collection->active());
+        $this->assertInstanceOf(Anomaly\Streams\Platform\Addon\Theme\Theme::class, $collection->active());
+        $this->assertFalse($collection->active()->isAdmin());
     }
 
     public function testCanReturnAdminThemes()


### PR DESCRIPTION
Replace TestTheme instance assertions with generic theme class + admin checks for each. This better reflects the intent of the collection tests and also doesn't break front end tests elsewhere.