### PR TITLE
Adjust test stubs

### DIFF
--- a/resources/stubs/addons/tests/feature.stub
+++ b/resources/stubs/addons/tests/feature.stub
@@ -1,6 +1,4 @@
-<?php
-
-namespace {namespace};
+<?php namespace {namespace};
 
 class {class} extends \TestCase
 {

--- a/resources/stubs/addons/tests/feature.stub
+++ b/resources/stubs/addons/tests/feature.stub
@@ -5,8 +5,8 @@ namespace {namespace};
 class {class} extends \TestCase
 {
 
-    public function testHome()
+    public function testFeature()
     {
-        // $this->visit('/');
+        $this->markTestSkipped('Not implemented.');
     }
 }

--- a/resources/stubs/addons/tests/test.stub
+++ b/resources/stubs/addons/tests/test.stub
@@ -1,6 +1,4 @@
-<?php
-
-namespace {namespace};
+<?php namespace {namespace};
 
 abstract class {class} extends \TestCase
 {

--- a/resources/stubs/addons/tests/test.stub
+++ b/resources/stubs/addons/tests/test.stub
@@ -4,5 +4,8 @@ namespace {namespace};
 
 abstract class {class} extends \TestCase
 {
-
+    public function testUnit()
+    {
+        $this->markTestSkipped('Not implemented.');
+    }
 }


### PR DESCRIPTION
Adjust test stubs to not generate warnings and be named more appropriately.