### PR TITLE
needed when using twig templates in queue jobs

### DIFF
--- a/src/View/Twig/Loader.php
+++ b/src/View/Twig/Loader.php
@@ -161,7 +161,9 @@ class Loader extends OriginalLoader
 
     protected function getPath($name)
     {
-
+        if (! $this->theme) {
+            return;
+        }
         $mobile = $this->mobiles->get($this->theme->getNamespace(), []);
 
         $_path = false;


### PR DESCRIPTION
In queue jobs theme is not set, so this is needed to avoid an exception on $this->theme->* related calls