### PR TITLE
Fixed an exception when getting rules

### DIFF
--- a/src/Field/FieldModel.php
+++ b/src/Field/FieldModel.php
@@ -271,6 +271,16 @@ class FieldModel extends EloquentModel implements FieldInterface
     {
         return ($this->locked);
     }
+    
+    /**
+     * Gets the rules.
+     *
+     * @return array The rules.
+     */
+    public function getRules()
+    {
+        return $this->getType()->getRules();
+    }
 
     /**
      * Set config attribute.


### PR DESCRIPTION
```php
    /**
     * Get the assignment's field's rules.
     *
     * @return array
     */
    public function getFieldRules()
    {
        $field = $this->getField();

        return $field->getRules();
    }
```
getRules is undefined on a field.