### PR TITLE
Removed annoying warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "erusev/parsedown-extra": "0.7.*",
         "kriswallsmith/assetic": "1.4.*",
         "leafo/scssphp": "0.6.*",
-        "lmammino/jsmin4assetic": "1.0.*",
         "natxet/CssMin": "3.0.*",
         "oyejorge/less.php": "1.7.*",
         "ptachoire/cssembed": "1.0.*",


### PR DESCRIPTION
> Warning: Ambiguous class resolution, "JSMin" was found in both "/PATH/vendor/lmammino/jsmin4assetic/src/JSMin.php" and "/PATH/vendor/linkorb/jsmin-php/src/jsmin-1.1.1.php", the first will be used.