### PR TITLE
Fix error in NL lang.

### DIFF
--- a/resources/lang/nl/assignment.php
+++ b/resources/lang/nl/assignment.php
@@ -32,10 +32,9 @@ return [
     'translatable' => [
         'name'         => 'Vertaalbaar',
         'label'        => 'Is dit veld vertaalbaar?',
-        'instructions' => 'Als het veld vertaalbaar is, zullen alle ingeschakelde locales beschikbaar zijn.'      => [
-            'column_type' => 'Het geassocieerde veld type ondersteund geen vertaalbare waardes.',
-            'stream'      => 'De geassocieerde stream is niet vertaalbaar.',
-        ],
+        'instructions' => 'Als het veld vertaalbaar is, zullen alle ingeschakelde locales beschikbaar zijn.',
+        'column_type'  => 'Het geassocieerde veld type ondersteund geen vertaalbare waardes.',
+        'stream'       => 'De geassocieerde stream is niet vertaalbaar.',
     ],
     'instructions' => [
         'name'         => 'Instructies',


### PR DESCRIPTION
This fixes a syntax error caused by an unexpected '=>'.