### PR TITLE
Update checking namespace formatting to something more strict.

### DIFF
--- a/src/Addon/Console/MakeAddon.php
+++ b/src/Addon/Console/MakeAddon.php
@@ -61,7 +61,7 @@ class MakeAddon extends Command
     {
         $namespace = $this->argument('namespace');
 
-        if (!str_is('*.*.*', $namespace)) {
+        if (preg_match('#^[a-zA-Z_]+\.[a-zA-Z_]+\.[a-zA-Z_]+\z#u', $namespace) !== 1) {
             throw new \Exception("The namespace should be snake case and formatted like: {vendor}.{type}.{slug}");
         }
 


### PR DESCRIPTION
str_is('*.*.*', $namespace) matched test-test.module.slug which is not valid. Changed it to preg_match so it really checks if the format is snake case.

See https://github.com/pyrocms/pyrocms/issues/4723