### PR TITLE
Update set a rows key if setTableEntries is used

### DIFF
--- a/src/Ui/Table/Component/Row/RowBuilder.php
+++ b/src/Ui/Table/Component/Row/RowBuilder.php
@@ -84,6 +84,8 @@ class RowBuilder
 
             if ($entry instanceof Model) {
                 $row['key'] = $entry->getKey();
+            } elseif(isset($entry['id'])){
+                $row['key'] = $entry['id'];
             }
 
             $row['table'] = $builder->getTable();

--- a/src/Ui/Table/Component/Row/RowBuilder.php
+++ b/src/Ui/Table/Component/Row/RowBuilder.php
@@ -84,7 +84,7 @@ class RowBuilder
 
             if ($entry instanceof Model) {
                 $row['key'] = $entry->getKey();
-            } elseif(isset($entry['id'])){
+            } elseif (isset($entry['id'])) {
                 $row['key'] = $entry['id'];
             }
 


### PR DESCRIPTION
Update the row builder so that a table row will have a key to be used when a checkbox is ticked for a non model row.

Right now nothing is returned `<input type="checkbox" name="id[]" value>`

This will set a value if the collection as an `id` field.