### PR TITLE
Only show the table footer when there's something to show

### DIFF
--- a/resources/views/table/partials/footer.twig
+++ b/resources/views/table/partials/footer.twig
@@ -1,51 +1,53 @@
-<tfoot>
-<tr>
-    <th colspan="50%" style="padding: 10px;">
+{% if table.actions|length or table.data.pagination.links|length %}
+	<tfoot>
+	<tr>
+	    <th colspan="50%" style="padding: 10px;">
 
-        <div class="pull-left actions">
-            {{ buttons(table.actions)|raw }}
-        </div>
+	        <div class="pull-left actions">
+	            {{ buttons(table.actions)|raw }}
+	        </div>
 
-        {% if table.data.pagination.links %}
-            <div class="pull-right">
+	        {% if table.data.pagination.links|length %}
+	            <div class="pull-right">
 
-                <select onchange="window.location=this.value;"
-                        class="custom-select table-limit">
-                    <option {{ table.options.limit == 5 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 5} + request_query()) }}">
-                        5 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 10 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 10} + request_query()) }}">
-                        10 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 15 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 15} + request_query()) }}">
-                        15 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 25 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 25} + request_query()) }}">
-                        25 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 50 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 50} + request_query()) }}">
-                        50 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 75 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 75} + request_query()) }}">
-                        75 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 100 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 100} + request_query()) }}">
-                        100 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 150 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 150} + request_query()) }}">
-                        150 {{ trans('streams::message.results') }}</option>
-                    <option {{ table.options.limit == 10000 ? 'selected' }}
-                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 10000} + request_query()) }}">
-                        {{ trans('streams::message.show_all') }}</option>
-                </select>
+	                <select onchange="window.location=this.value;"
+	                        class="custom-select table-limit">
+	                    <option {{ table.options.limit == 5 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 5} + request_query()) }}">
+	                        5 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 10 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 10} + request_query()) }}">
+	                        10 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 15 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 15} + request_query()) }}">
+	                        15 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 25 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 25} + request_query()) }}">
+	                        25 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 50 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 50} + request_query()) }}">
+	                        50 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 75 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 75} + request_query()) }}">
+	                        75 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 100 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 100} + request_query()) }}">
+	                        100 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 150 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 150} + request_query()) }}">
+	                        150 {{ trans('streams::message.results') }}</option>
+	                    <option {{ table.options.limit == 10000 ? 'selected' }}
+	                            value="{{ url_current() }}?{{ http_build_query({(table.options.prefix ~ 'limit'): 10000} + request_query()) }}">
+	                        {{ trans('streams::message.show_all') }}</option>
+	                </select>
 
-                {{ table.data.pagination.links|raw }}
-            </div>
-        {% endif %}
+	                {{ table.data.pagination.links|raw }}
+	            </div>
+	        {% endif %}
 
-        <div style="clear: both;"></div>
+	        <div style="clear: both;"></div>
 
-    </th>
-</tr>
-</tfoot>
+	    </th>
+	</tr>
+	</tfoot>
+{% endif %}


### PR DESCRIPTION
First off, `{% if table.data.pagination.links %}` evaluates to true even when there aren't links, so the footer was showing even if there wasn't any pagination. This resulted in the per-page dropdown showing even when you only had one page of results. I fixed this by adding the `length` filter.

I also surrounded the entire output in a conditional to check if there's anything to actually show in the footer. If not...no footer.