### PR TITLE
Make readonly fields writable again

### DIFF
--- a/src/Ui/Form/Component/Field/FieldCollection.php
+++ b/src/Ui/Form/Component/Field/FieldCollection.php
@@ -172,7 +172,7 @@ class FieldCollection extends Collection
             function ($item) {
 
                 /* @var FieldType $item */
-                return !$item->isReadonly();
+                return !$item->isDisabled();
             }
         );
     }


### PR DESCRIPTION
We have always been able to mark a field as read only so that we can pre-populate data for a form, then mark it read only so it can be shown to a user, and saved into the database.

When we talked about how to do this, you said to mark them as `readOnly` fields so that they can be shown to the user, and passed to the handler to be saved.

We talked about if it should be `disabled` or not, you said no because those won't be saved, as intended, you put in a patch with writable field logic, which said if its `readOnly`, you can't save the field.

That makes it so we can't populate a field and have it savable

I'm proposing changing the writable logic to say if `isDisabled()` to filter out the fields vs `isReadOnly()`
That will put the functionality back to how it used to operate