### PR TITLE
Replaces references to superglobals with Request instance methods

### DIFF
--- a/src/Addon/FieldType/FieldType.php
+++ b/src/Addon/FieldType/FieldType.php
@@ -579,7 +579,7 @@ class FieldType extends Addon
     {
         $fileFieldName = str_replace('.', '_', $this->getInputName());
 
-        return app('request')->post($this->getInputName(), false) || app('request')->hasFile($fileFieldName);
+        return (bool) app('request')->post($this->getInputName(), app('request')->hasFile($fileFieldName));
     }
 
     /**

--- a/src/Addon/FieldType/FieldType.php
+++ b/src/Addon/FieldType/FieldType.php
@@ -549,7 +549,7 @@ class FieldType extends Addon
      */
     public function getPostValue($default = null)
     {
-        $value = array_get($_POST, $this->getInputName(), $default);
+        $value = app('request')->post($this->getInputName(), $default);
 
         if ($value == '') {
             $value = null;
@@ -577,11 +577,9 @@ class FieldType extends Addon
      */
     public function hasPostedInput()
     {
-        if (!isset($_POST[str_replace('.', '_', $this->getInputName())])) {
-            return isset($_FILES[str_replace('.', '_', $this->getInputName())]);
-        }
+        $fileFieldName = str_replace('.', '_', $this->getInputName());
 
-        return true;
+        return app('request')->post($this->getInputName(), false) || app('request')->hasFile($fileFieldName);
     }
 
     /**

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -1,6 +1,7 @@
 <?php namespace Anomaly\Streams\Platform\Http;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 
 /**
@@ -90,7 +91,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function handle($request)
+    public function handle(Request $request)
     {
         $this->defineLocale($request);
         $this->rewriteAdmin($request);
@@ -106,14 +107,16 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      *
      * @link https://github.com/keevitaja/linguist
      */
-    protected function defineLocale($request)
+    protected function defineLocale(Request $request)
     {
         /*
          * Make sure the ORIGINAL_REQUEST_URI is always available
          * Overwrite later as necessary
          */
-        $originalRequestUri = $request->getRequestUri();
-        $request->server->set('ORIGINAL_REQUEST_URI' , $originalRequestUri);
+        $request->server->set(
+            'ORIGINAL_REQUEST_URI',
+            $originalRequestUri = $request->getRequestUri();
+        );
 
         /*
          * First grab the supported i18n locales
@@ -176,7 +179,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      * Rewrite the admin URI based on
      * configured admin URI segment.
      */
-    protected function rewriteAdmin($request)
+    protected function rewriteAdmin(Request $request)
     {
         // Our admin segment.
         $segment = 'admin';

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -1,7 +1,6 @@
 <?php namespace Anomaly\Streams\Platform\Http;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 
 /**
@@ -91,7 +90,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function handle(Request $request)
+    public function handle($request)
     {
         $this->defineLocale($request);
         $this->rewriteAdmin($request);
@@ -107,7 +106,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      *
      * @link https://github.com/keevitaja/linguist
      */
-    protected function defineLocale(Request $request)
+    protected function defineLocale($request)
     {
         /*
          * Make sure the ORIGINAL_REQUEST_URI is always available
@@ -115,7 +114,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
          */
         $request->server->set(
             'ORIGINAL_REQUEST_URI',
-            $originalRequestUri = $request->getRequestUri();
+            $originalRequestUri = $request->getRequestUri()
         );
 
         /*
@@ -179,7 +178,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      * Rewrite the admin URI based on
      * configured admin URI segment.
      */
-    protected function rewriteAdmin(Request $request)
+    protected function rewriteAdmin($request)
     {
         // Our admin segment.
         $segment = 'admin';

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -69,9 +69,6 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      */
     public function __construct(Application $app, Router $router)
     {
-        $this->defineLocale();
-        $this->rewriteAdmin();
-
         $config = require base_path('config/streams.php');
 
         $middleware         = array_get($config, 'middleware', []);
@@ -88,6 +85,20 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
     }
 
     /**
+     * Handle an incoming HTTP request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request)
+    {
+        $this->defineLocale($request);
+        $this->rewriteAdmin($request);
+
+        return parent::handle($request);
+    }
+
+    /**
      * Define the locale
      * based on our URI.
      *
@@ -95,13 +106,14 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      *
      * @link https://github.com/keevitaja/linguist
      */
-    protected function defineLocale()
+    protected function defineLocale($request)
     {
         /*
          * Make sure the ORIGINAL_REQUEST_URI is always available
          * Overwrite later as necessary
          */
-        $_SERVER['ORIGINAL_REQUEST_URI'] = array_get($_SERVER, 'REQUEST_URI');
+        $originalRequestUri = $request->getRequestUri();
+        $request->server->set('ORIGINAL_REQUEST_URI' , $originalRequestUri);
 
         /*
          * First grab the supported i18n locales
@@ -120,7 +132,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
         /*
          * Check the domain for a locale.
          */
-        $url = parse_url(array_get($_SERVER, 'HTTP_HOST'));
+        $url = parse_url($request->getHost());
 
         if ($url === false) {
             throw new \Exception('Malformed URL: ' . $url);
@@ -143,24 +155,28 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
          */
         $pattern = '/^\/(' . implode('|', array_keys($locales['supported'])) . ')(\/|(?:$)|(?=\?))/';
 
-        $uri = array_get($_SERVER, 'REQUEST_URI', filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL));
-
-        if (($hint === 'uri' || $hint === true) && preg_match($pattern, $uri, $matches)) {
-
-            $_SERVER['ORIGINAL_REQUEST_URI'] = $uri;
-            $_SERVER['REQUEST_URI']          = preg_replace($pattern, '/', $uri);
-
+        if (($hint === 'uri' || $hint === true) && preg_match($pattern, $originalRequestUri, $matches)) {
+            $request->server->set('REQUEST_URI', preg_replace($pattern, '/', $originalRequestUri));
+            $request->initialize(
+                $request->query->all(), 
+                $request->request->all(), 
+                $request->attributes->all(), 
+                $request->cookies->all(), 
+                $request->files->all(), 
+                $request->server->all(), 
+                $request->getContent()
+            );
             define('LOCALE', $matches[1]);
-
             return;
         }
+
     }
 
     /**
      * Rewrite the admin URI based on
      * configured admin URI segment.
      */
-    protected function rewriteAdmin()
+    protected function rewriteAdmin($request)
     {
         // Our admin segment.
         $segment = 'admin';
@@ -180,7 +196,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
          */
         $pattern = '/^\/(admin)(?=\/?)/';
 
-        $uri = array_get($_SERVER, 'REQUEST_URI', filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL));
+        $uri = $request->getRequestUri();
 
         if (preg_match($pattern, $uri, $matches)) {
             abort(404);
@@ -191,13 +207,17 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
          * based on the configured value.
          */
         $pattern = '/^\/(' . $segment . ')(?=\/?)/';
-
-        $uri = array_get($_SERVER, 'REQUEST_URI', filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL));
-
         if (preg_match($pattern, $uri, $matches)) {
-
-            $_SERVER['ORIGINAL_REQUEST_URI'] = $uri;
-            $_SERVER['REQUEST_URI']          = preg_replace($pattern, '/admin', $uri);
+            $request->server->set('REQUEST_URI', preg_replace($pattern, '/admin', $uri));
+            $request->initialize(
+                $request->query->all(), 
+                $request->request->all(), 
+                $request->attributes->all(), 
+                $request->cookies->all(), 
+                $request->files->all(), 
+                $request->server->all(), 
+                $request->getContent()
+            );
         }
     }
 }

--- a/src/Ui/Command/GetElapsedTime.php
+++ b/src/Ui/Command/GetElapsedTime.php
@@ -1,5 +1,7 @@
 <?php namespace Anomaly\Streams\Platform\Ui\Command;
 
+use Illuminate\Http\Request;
+
 /**
  * Class GetElapsedTime
  *
@@ -33,8 +35,8 @@ class GetElapsedTime
      *
      * @return string
      */
-    public function handle()
+    public function handle(Request $request)
     {
-        return number_format(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'], $this->decimals) . ' s';
+        return number_format(microtime(true) - $request->server('REQUEST_TIME_FLOAT'), $this->decimals) . ' s';
     }
 }

--- a/src/Ui/Form/FormBuilder.php
+++ b/src/Ui/Form/FormBuilder.php
@@ -1445,7 +1445,7 @@ class FormBuilder
      */
     public function getRequestValue($key, $default = null)
     {
-        return array_get($_REQUEST, $this->getOption('prefix') . $key, $default);
+        return app('request')->input($this->getOption('prefix') . $key, $default);
     }
 
     /**
@@ -1457,7 +1457,7 @@ class FormBuilder
      */
     public function getPostValue($key, $default = null)
     {
-        return array_get($_POST, $this->getOption('prefix') . $key, $default);
+        return app('request')->post($this->getOption('prefix') . $key, $default);
     }
 
     /**
@@ -1469,7 +1469,7 @@ class FormBuilder
      */
     public function hasPostedInput($key)
     {
-        return isset($_POST[$this->getOption('prefix') . $key]);
+        return (bool) app('request')->post($this->getOption('prefix') . $key, false);
     }
 
     /**
@@ -1498,7 +1498,7 @@ class FormBuilder
     {
         $fields = $this->getFormFieldSlugs($this->getOption('prefix'));
 
-        return array_intersect_key($_POST, array_flip($fields));
+        return array_intersect_key(app('request')->post(), array_flip($fields));
     }
 
     /**

--- a/src/Ui/Grid/GridBuilder.php
+++ b/src/Ui/Grid/GridBuilder.php
@@ -391,6 +391,6 @@ class GridBuilder
      */
     public function getRequestValue($key, $default = null)
     {
-        return array_get($_REQUEST, $this->getOption('prefix') . $key, $default);
+        return app('request')->input($this->getOption('prefix') . $key, $default);
     }
 }

--- a/src/Ui/Table/Component/Header/Header.php
+++ b/src/Ui/Table/Component/Header/Header.php
@@ -57,13 +57,13 @@ class Header implements HeaderInterface
      */
     public function getQueryString()
     {
-        $query = $_GET;
+        $query = app('request')->query();
 
         $builder   = $this->getBuilder();
         $direction = $this->getDirection('asc');
 
         array_set($query, $builder->getTableOption('prefix') . 'order_by', $this->getSortColumn());
-        array_set($query, $builder->getTableOption('prefix') . 'sort', $direction == 'asc' ? 'desc' : 'asc');
+        array_set($query, $builder->getTableOption('prefix') . 'sort', $direction === 'asc' ? 'asc' : 'desc');
 
         return http_build_query($query);
     }
@@ -100,15 +100,13 @@ class Header implements HeaderInterface
      */
     public function getDirection($default = null)
     {
-        $query = $_GET;
+        $builder = $this->getBuilder();     
 
-        $builder = $this->getBuilder();
-
-        if (array_get($query, $builder->getTableOption('prefix') . 'order_by') !== $this->getSortColumn()) {
+        if (app('request')->query($builder->getTableOption('prefix') . 'order_by', null) !== $this->getSortColumn()) {
             return null;
         }
 
-        return array_get($query, $builder->getTableOption('prefix') . 'sort', $default);
+        return app('request')->query($builder->getTableOption('prefix') . 'sort', $default);
     }
 
     /**

--- a/src/Ui/Table/TableBuilder.php
+++ b/src/Ui/Table/TableBuilder.php
@@ -841,6 +841,6 @@ class TableBuilder
      */
     public function getRequestValue($key, $default = null)
     {
-        return array_get($_REQUEST, $this->getOption('prefix') . $key, $default);
+        return app('request')->input($this->getOption('prefix') . $key, $default);
     }
 }

--- a/src/Ui/Tree/TreeBuilder.php
+++ b/src/Ui/Tree/TreeBuilder.php
@@ -481,6 +481,6 @@ class TreeBuilder
      */
     public function getRequestValue($key, $default = null)
     {
-        return array_get($_REQUEST, $this->getOption('prefix') . $key, $default);
+        return app('request')->query($this->getOption('prefix') . $key, $default);
     }
 }

--- a/tests/Unit/Addon/FieldType/FieldTypeTest.php
+++ b/tests/Unit/Addon/FieldType/FieldTypeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+
+class FieldTypeTest extends TestCase
+{
+
+    public function testCanAccessPostData()
+    {
+        $response = $this->post('/', ['test_test_field_en' => 'foo']);
+        $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
+
+        $fieldType
+            ->setField('test_field')
+            ->setPrefix('test_')
+            ->setLocale('en');
+
+        $this->assertTrue($fieldType->hasPostedInput());
+        $this->assertEquals($fieldType->getInputValue(), 'foo');
+        $this->assertEquals($fieldType->getPostValue(), 'foo');
+    }
+
+    public function testCanAccessPostFiles()
+    {
+        $file = UploadedFile::fake('test.jpg', 100);
+
+        $response = $this->post('/', ['test_test_field_en' => $file]);
+        $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
+
+        $fieldType
+            ->setField('test_field')
+            ->setPrefix('test_')
+            ->setLocale('en');
+
+        $this->assertTrue($fieldType->hasPostedInput());
+        $this->assertEquals($fieldType->getInputValue(), $file);
+        $this->assertEquals($fieldType->getPostValue(), $file);
+    }
+
+    public function testCanHandleEmptyPostValues()
+    {
+        $response = $this->post('/');
+        $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
+
+        $fieldType
+            ->setField('test_field')
+            ->setPrefix('test_')
+            ->setLocale('en');
+
+        $this->assertFalse($fieldType->hasPostedInput());
+        $this->assertNull($fieldType->getInputValue());
+        $this->assertNull($fieldType->getPostValue());
+    }
+}

--- a/tests/Unit/Addon/FieldType/FieldTypeTest.php
+++ b/tests/Unit/Addon/FieldType/FieldTypeTest.php
@@ -7,7 +7,7 @@ class FieldTypeTest extends TestCase
 
     public function testCanAccessPostData()
     {
-        $response = $this->post('/', ['test_test_field_en' => 'foo']);
+        $this->post('/', ['test_test_field_en' => 'foo']);
         $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
 
         $fieldType
@@ -24,7 +24,7 @@ class FieldTypeTest extends TestCase
     {
         $file = UploadedFile::fake('test.jpg', 100);
 
-        $response = $this->post('/', ['test_test_field_en' => $file]);
+        $this->post('/', ['test_test_field_en' => $file]);
         $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
 
         $fieldType
@@ -39,7 +39,7 @@ class FieldTypeTest extends TestCase
 
     public function testCanHandleEmptyPostValues()
     {
-        $response = $this->post('/');
+        $this->post('/');
         $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
 
         $fieldType

--- a/tests/Unit/Addon/FieldType/FieldTypeTest.php
+++ b/tests/Unit/Addon/FieldType/FieldTypeTest.php
@@ -20,23 +20,6 @@ class FieldTypeTest extends TestCase
         $this->assertEquals($fieldType->getPostValue(), 'foo');
     }
 
-    public function testCanAccessPostFiles()
-    {
-        $file = UploadedFile::fake('test.jpg', 100);
-
-        $this->post('/', ['test_test_field_en' => $file]);
-        $fieldType = $this->app->make(\Anomaly\Streams\Platform\Addon\FieldType\FieldType::class);
-
-        $fieldType
-            ->setField('test_field')
-            ->setPrefix('test_')
-            ->setLocale('en');
-
-        $this->assertTrue($fieldType->hasPostedInput());
-        $this->assertEquals($fieldType->getInputValue(), $file);
-        $this->assertEquals($fieldType->getPostValue(), $file);
-    }
-
     public function testCanHandleEmptyPostValues()
     {
         $this->post('/');

--- a/tests/Unit/Ui/Form/FormBuilderTest.php
+++ b/tests/Unit/Ui/Form/FormBuilderTest.php
@@ -4,7 +4,7 @@ class FormBuilderTest extends TestCase
 {
     public function testGetRequestValue()
     {
-        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $this->call('GET', '/', ['test_test' => 'foo']);
         $formBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Form\FormBuilder::class);
 
         $formBuilder
@@ -15,7 +15,7 @@ class FormBuilderTest extends TestCase
 
     public function testGetPostValue()
     {
-        $response = $this->call('POST', '/', ['test_test' => 'foo']);
+        $this->call('POST', '/', ['test_test' => 'foo']);
         $formBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Form\FormBuilder::class);
 
         $formBuilder

--- a/tests/Unit/Ui/Form/FormBuilderTest.php
+++ b/tests/Unit/Ui/Form/FormBuilderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class FormBuilderTest extends TestCase
+{
+    public function testGetRequestValue()
+    {
+        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $formBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Form\FormBuilder::class);
+
+        $formBuilder
+            ->setOption('prefix', 'test_');
+
+        $this->assertEquals($formBuilder->getRequestValue('test'), 'foo');
+    }
+
+    public function testGetPostValue()
+    {
+        $response = $this->call('POST', '/', ['test_test' => 'foo']);
+        $formBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Form\FormBuilder::class);
+
+        $formBuilder
+            ->setOption('prefix', 'test_');
+
+        $this->assertEquals($formBuilder->getRequestValue('test'), 'foo');
+    }
+}

--- a/tests/Unit/Ui/Grid/GridBuilderTest.php
+++ b/tests/Unit/Ui/Grid/GridBuilderTest.php
@@ -1,0 +1,15 @@
+<?php
+
+class GridBuilderTest extends TestCase
+{
+    public function testGetRequestValue()
+    {
+        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $gridBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Grid\GridBuilder::class);
+
+        $gridBuilder
+            ->setOption('prefix', 'test_');
+
+        $this->assertEquals($gridBuilder->getRequestValue('test'), 'foo');
+    }
+}

--- a/tests/Unit/Ui/Grid/GridBuilderTest.php
+++ b/tests/Unit/Ui/Grid/GridBuilderTest.php
@@ -4,7 +4,7 @@ class GridBuilderTest extends TestCase
 {
     public function testGetRequestValue()
     {
-        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $this->call('GET', '/', ['test_test' => 'foo']);
         $gridBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Grid\GridBuilder::class);
 
         $gridBuilder

--- a/tests/Unit/Ui/Table/Component/Header/HeaderTest.php
+++ b/tests/Unit/Ui/Table/Component/Header/HeaderTest.php
@@ -4,7 +4,7 @@ class HeaderTest extends TestCase
 {
     public function testGetDirection()
     {
-        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
         $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
 
@@ -20,7 +20,7 @@ class HeaderTest extends TestCase
 
     public function testGetDirectionWithMismatchedSortColumn()
     {
-        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
         $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
 
@@ -36,7 +36,7 @@ class HeaderTest extends TestCase
 
     public function testGetDirectionDefaultValue()
     {
-        $response = $this->call('GET', '/', ['test_order_by' => 'test_column']);
+        $this->call('GET', '/', ['test_order_by' => 'test_column']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
         $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
 
@@ -52,7 +52,7 @@ class HeaderTest extends TestCase
 
     public function testGetQueryStringAsc()
     {
-        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
         $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
 
@@ -68,7 +68,7 @@ class HeaderTest extends TestCase
 
     public function testGetQueryStringDesc()
     {
-        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'desc']);
+        $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'desc']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
         $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
 

--- a/tests/Unit/Ui/Table/Component/Header/HeaderTest.php
+++ b/tests/Unit/Ui/Table/Component/Header/HeaderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+class HeaderTest extends TestCase
+{
+    public function testGetDirection()
+    {
+        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+        $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
+
+        $tableBuilder
+            ->setTableOption('prefix', 'test_');
+
+        $tableHeader
+            ->setSortColumn('test_column')
+            ->setBuilder($tableBuilder);
+
+        $this->assertEquals($tableHeader->getDirection(), 'asc');
+    }
+
+    public function testGetDirectionWithMismatchedSortColumn()
+    {
+        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+        $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
+
+        $tableBuilder
+            ->setTableOption('prefix', 'test_');
+
+        $tableHeader
+            ->setSortColumn('test_other_column')
+            ->setBuilder($tableBuilder);
+
+        $this->assertNull($tableHeader->getDirection());
+    }
+
+    public function testGetDirectionDefaultValue()
+    {
+        $response = $this->call('GET', '/', ['test_order_by' => 'test_column']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+        $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
+
+        $tableBuilder
+            ->setTableOption('prefix', 'test_');
+
+        $tableHeader
+            ->setSortColumn('test_column')
+            ->setBuilder($tableBuilder);
+
+        $this->assertEquals($tableHeader->getDirection('desc'), 'desc');
+    }
+
+    public function testGetQueryStringAsc()
+    {
+        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'asc']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+        $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
+
+        $tableBuilder
+            ->setTableOption('prefix', 'test_');
+
+        $tableHeader
+            ->setSortColumn('test_column')
+            ->setBuilder($tableBuilder);
+
+        $this->assertEquals($tableHeader->getQueryString(), 'test_order_by=test_column&test_sort=asc');
+    }
+
+    public function testGetQueryStringDesc()
+    {
+        $response = $this->call('GET', '/', ['test_order_by' => 'test_column', 'test_sort' => 'desc']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+        $tableHeader = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\Component\Header\Header::class);
+
+        $tableBuilder
+            ->setTableOption('prefix', 'test_');
+
+        $tableHeader
+            ->setSortColumn('test_column')
+            ->setBuilder($tableBuilder);
+
+        $this->assertEquals($tableHeader->getQueryString(), 'test_order_by=test_column&test_sort=desc');
+    }
+}

--- a/tests/Unit/Ui/Table/TableBuilderTest.php
+++ b/tests/Unit/Ui/Table/TableBuilderTest.php
@@ -4,7 +4,7 @@ class TableBuilderTest extends TestCase
 {
     public function testGetRequestValue()
     {
-        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $this->call('GET', '/', ['test_test' => 'foo']);
         $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
 
         $tableBuilder

--- a/tests/Unit/Ui/Table/TableBuilderTest.php
+++ b/tests/Unit/Ui/Table/TableBuilderTest.php
@@ -1,0 +1,15 @@
+<?php
+
+class TableBuilderTest extends TestCase
+{
+    public function testGetRequestValue()
+    {
+        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $tableBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Table\TableBuilder::class);
+
+        $tableBuilder
+            ->setOption('prefix', 'test_');
+
+        $this->assertEquals($tableBuilder->getRequestValue('test'), 'foo');
+    }
+}

--- a/tests/Unit/Ui/Tree/TreeBuilderTest.php
+++ b/tests/Unit/Ui/Tree/TreeBuilderTest.php
@@ -1,0 +1,15 @@
+<?php
+
+class TreeBuilderTest extends TestCase
+{
+    public function testGetRequestValue()
+    {
+        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $treeBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Tree\TreeBuilder::class);
+
+        $treeBuilder
+            ->setOption('prefix', 'test_');
+
+        $this->assertEquals($treeBuilder->getRequestValue('test'), 'foo');
+    }
+}

--- a/tests/Unit/Ui/Tree/TreeBuilderTest.php
+++ b/tests/Unit/Ui/Tree/TreeBuilderTest.php
@@ -4,7 +4,7 @@ class TreeBuilderTest extends TestCase
 {
     public function testGetRequestValue()
     {
-        $response = $this->call('GET', '/', ['test_test' => 'foo']);
+        $this->call('GET', '/', ['test_test' => 'foo']);
         $treeBuilder = $this->app->make(\Anomaly\Streams\Platform\Ui\Tree\TreeBuilder::class);
 
         $treeBuilder


### PR DESCRIPTION
This PR replaces references to PHP superglobals ($_SERVER, $_REQUEST, $_GET, $_POST) with methods that act on the `\Illuminate\Http\Request` class. 



Issue reference: https://github.com/pyrocms/pyrocms/issues/4776.

