### PR TITLE
Allowing to use only a set of locales

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -113,6 +113,10 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
             $locales = array_replace_recursive($locales, require $override);
         }
 
+        if (file_exists($override = __DIR__ . '/../../../../../resources/streams/config/locales.php')) {
+            $locales = array_replace($locales, require $override);
+        }
+
         if (!$hint = array_get($locales, 'hint')) {
             return;
         }


### PR DESCRIPTION
We really need something to disable URL locales (/de/, /fr/ etc). In the Kernel, I wanted to change `array_replace_recursive($locales, require $override)` by `array_replace`
https://github.com/anomalylabs/streams-platform/blob/42257569e211d2b54b642e9c8ae68945cd36570a/src/Http/Kernel.php#L113
So we could manage `supported` by ourself. But it is a breaking change.


Then I noticed that the override `locales.php` is not at the usual path (`resources/streams/config`) but instead `resources/core/config/streams/locales.php`.

Not sure if it is on propose? Anyway, I tried to change the one in `resources/streams/config` to see what happen... And well nothing of course for the URL. But it do limit the settings of the BO.

So why not using both override files? The current one (else it will be a breaking change) and adding the "normal" override file, but with the normal Laravel behaviour  (so using `array_replace`).

```
return [
    'supported' => [
        'en' => [
            'direction' => 'ltr',
        ],
        'fr' => [
            'direction' => 'ltr',
        ],
    ]
];
```

With this code in the override file, it will limit the BO settings to EN and FR but also the URLs to /en and /fr.
