### PR TITLE
Do not return relation

### DIFF
--- a/src/Model/Traits/Translatable.php
+++ b/src/Model/Traits/Translatable.php
@@ -170,6 +170,10 @@ trait Translatable
      */
     public function translations()
     {
+        if (!$this->getTranslationModelName()) {
+            return null;
+        }
+
         return $this->hasMany($this->getTranslationModelName(), $this->getRelationKey());
     }
 

--- a/src/Model/Traits/Translatable.php
+++ b/src/Model/Traits/Translatable.php
@@ -170,11 +170,11 @@ trait Translatable
      */
     public function translations()
     {
-        if (!$this->getTranslationModelName()) {
+        if (!$model = $this->getTranslationModelName()) {
             return null;
         }
 
-        return $this->hasMany($this->getTranslationModelName(), $this->getRelationKey());
+        return $this->hasMany($model, $this->getRelationKey());
     }
 
     /**


### PR DESCRIPTION
Avoid error if `translations` is used on non-translatable model (e.g. ide helper will trigger it)