### PR TITLE
Allow to for the default locale route

### DIFF
--- a/src/Http/Middleware/CheckLocale.php
+++ b/src/Http/Middleware/CheckLocale.php
@@ -47,6 +47,10 @@ class CheckLocale
          * absolutely nothing to do.
          */
         if (!defined('LOCALE')) {
+            if (1 === $this->config->get('streams::locales.default_redirect')) {
+                return redirect($this->config->get('streams::locales.default') . '/' . $request->route()->uri());
+            }
+
             return $next($request);
         }
 
@@ -57,6 +61,12 @@ class CheckLocale
          */
         if (!in_array(strtolower(LOCALE), $this->config->get('streams::locales.enabled'))) {
             abort(404);
+        }
+
+        if (2 === $this->config->get('streams::locales.default_redirect')
+            && LOCALE == $this->config->get('streams::locales.default')
+        ) {
+            return redirect($request->route()->uri());
         }
 
         return $next($request);


### PR DESCRIPTION
Currently the URL with the default locale or without are the same (e.g. `/services` and `/en/services`) not the best for SEO. And most of the customers don't want this kind of behaviour.

So we can just add a settings to allow to change this behaviour.

* None (default), nothing change, both URL are avalaible
* 1, the URL without locale will redirect to the URL with
* 2, the URL with locale will redirect to the URL without