### PR TITLE
Allow listener during install

### DIFF
--- a/src/Installer/Console/Command/LoadModuleListeners.php
+++ b/src/Installer/Console/Command/LoadModuleListeners.php
@@ -1,0 +1,56 @@
+<?php namespace Anomaly\Streams\Platform\Installer\Console\Command;
+
+use Anomaly\Streams\Platform\Addon\Module\Module;
+use Anomaly\Streams\Platform\Addon\Module\ModuleCollection;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * Class LoadModuleInstallers
+ *
+ * @link   http://pyrocms.com/
+ * @author PyroCMS, Inc. <support@pyrocms.com>
+ * @author Ryan Thompson <ryan@pyrocms.com>
+ */
+class LoadModuleListeners
+{
+    /**
+     * Handle the command.
+     *
+     * @param ModuleCollection $modules
+     * @param Dispatcher       $events
+     */
+    public function handle(ModuleCollection $modules, Dispatcher $events)
+    {
+        /* @var Module $module */
+        foreach ($modules as $module) {
+            if ($module->getNamespace() == 'anomaly.module.installer') {
+                continue;
+            }
+
+            $provider = $module->getServiceProvider();
+
+            if (!class_exists($provider)) {
+                continue;
+            }
+
+            $provider = $module->newServiceProvider();
+
+            if (!$listen = $provider->getListeners()) {
+                continue;
+            }
+
+            foreach ($listen as $event => $listeners) {
+                foreach ($listeners as $key => $listener) {
+                    if (is_integer($listener)) {
+                        $priority = $listener;
+                        $listener = $key;
+                    } else {
+                        $priority = 0;
+                    }
+
+                    $events->listen($event, $listener, $priority);
+                }
+            }
+        }
+    }
+}

--- a/src/Installer/Console/Install.php
+++ b/src/Installer/Console/Install.php
@@ -15,6 +15,7 @@ use Anomaly\Streams\Platform\Installer\Console\Command\LoadCoreInstallers;
 use Anomaly\Streams\Platform\Installer\Console\Command\LoadExtensionInstallers;
 use Anomaly\Streams\Platform\Installer\Console\Command\LoadExtensionSeeders;
 use Anomaly\Streams\Platform\Installer\Console\Command\LoadModuleInstallers;
+use Anomaly\Streams\Platform\Installer\Console\Command\LoadModuleListeners;
 use Anomaly\Streams\Platform\Installer\Console\Command\LoadModuleSeeders;
 use Anomaly\Streams\Platform\Installer\Console\Command\RunInstallers;
 use Anomaly\Streams\Platform\Installer\Console\Command\SetAdminData;
@@ -85,6 +86,8 @@ class Install extends Command
 
         $this->dispatch(new ConfigureDatabase());
         $this->dispatch(new SetDatabasePrefix());
+
+        $this->dispatch(new LoadModuleListeners());
 
         $installers = new InstallerCollection();
 


### PR DESCRIPTION
Enable the listener during `install`, allowing module to interact together