### PR TITLE
Don’t use the parent translation when value is “0”

### DIFF
--- a/src/Entry/EntryTranslationsModel.php
+++ b/src/Entry/EntryTranslationsModel.php
@@ -194,7 +194,7 @@ class EntryTranslationsModel extends EloquentModel
     {
         $value = parent::__get($key);
 
-        if (!$value && $parent = $this->getParent()) {
+        if (!isset($value) && $parent = $this->getParent()) {
             return $parent->{$key};
         }
 


### PR DESCRIPTION
If the value of an attribute was 0, don’t default to the parent because “0” represents an explicit choice in boolean fields.  We ran into this when localizing switch-type boolean fields.