### PR TITLE
Fixing an issue with NULL translated file relations

### DIFF
--- a/src/Entry/EntryTranslationsModel.php
+++ b/src/Entry/EntryTranslationsModel.php
@@ -194,6 +194,15 @@ class EntryTranslationsModel extends EloquentModel
     {
         $value = parent::__get($key);
 
+        // Check if the attribute was actually a foreign key and resolve it.
+        // This solves for an issue where a translated relationship column to
+        // a file (like image_id) was causing a `property not defined error`
+        // if it had a NULL value.
+        if (!isset($value)
+            && array_key_exists($key.'_id', $this->attributes)) {
+            return $this->{$key.'_id'};
+        }
+
         if (!$value && $parent = $this->getParent()) {
             return $parent->{$key};
         }


### PR DESCRIPTION
This fixes an issue I encountered with translated file references who have a null value.  On a listing page in the CMS for a model that had translated file references with NULL values, I would see this error:

![](http://yo.bkwld.com/d958e6e78b3d/Image%202018-12-07%20at%204.59.29%20PM.png)

In the screenshotted example, my attribute was named `file`.