### PR TITLE
Update EloquentModel.php

### DIFF
--- a/src/Model/EloquentModel.php
+++ b/src/Model/EloquentModel.php
@@ -246,7 +246,7 @@ class EloquentModel extends Model implements Arrayable, PresentableInterface
      */
     public function getCacheCollectionKey()
     {
-        return get_called_class();
+        return static::class;
     }
 
     /**


### PR DESCRIPTION
eplace get_called_class()  `get_called_class()` can be securely replaced with `static::class`. Also, this function will be marked as deprecated in PHP 7.4:  https://wiki.php.net/rfc/deprecations_php_7_4#get_called_clas