### PR TITLE
Aliasing the route middleware

### DIFF
--- a/src/Addon/AddonProvider.php
+++ b/src/Addon/AddonProvider.php
@@ -594,6 +594,7 @@ class AddonProvider
     protected function registerRouteMiddleware(AddonServiceProvider $provider)
     {
         foreach ($provider->getRouteMiddleware() as $name => $class) {
+            $this->router->aliasMiddleware($name, $class);
             $this->router->middleware($name, $class);
         }
     }


### PR DESCRIPTION
Route alias are not registered to the router. So using them in `public function map(Router $router)` is not working.

e.g.

```php
    ...
    protected $routeMiddleware = [
        'contents' => ContentMiddleware::class
    ];

    public function map(Router $router)
    {
            $router
                ->name('contents.show')
                ->middleware('contents')
                ->get('{contentSlug}', 'ContentsController@show');
    ...
```

Will fail

```
Class contents does not exist
```