### PR TITLE
Remove duplicate middleware

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -56,10 +56,6 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \Illuminate\Cookie\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],


### PR DESCRIPTION
The cookie and session middleware are already being defined in the global middleware stack above. Therefore there's no need to redefine them for the web middleware group.