### PR TITLE
Extend Laravel's VerifyCsrfToken

### DIFF
--- a/src/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Http/Middleware/VerifyCsrfToken.php
@@ -4,11 +4,9 @@ use Anomaly\Streams\Platform\Message\MessageBag;
 use Closure;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Foundation\Application;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\Route;
-use Illuminate\Support\InteractsWithTime;
-use Symfony\Component\HttpFoundation\Cookie;
+use Illuminate\Session\TokenMismatchException;
 
 /**
  * Class VerifyCsrfToken
@@ -17,38 +15,14 @@ use Symfony\Component\HttpFoundation\Cookie;
  * @author PyroCMS, Inc. <support@pyrocms.com>
  * @author Ryan Thompson <ryan@pyrocms.com>
  */
-class VerifyCsrfToken
+class VerifyCsrfToken extends \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken
 {
-
-    use InteractsWithTime;
-
-    /**
-     * The application instance.
-     *
-     * @var \Illuminate\Foundation\Application
-     */
-    protected $app;
-
     /**
      * The route instance.
      *
      * @var Route
      */
     protected $route;
-
-    /**
-     * The encrypter implementation.
-     *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
-     */
-    protected $encrypter;
-
-    /**
-     * The URIs that should be excluded from CSRF verification.
-     *
-     * @var array
-     */
-    protected $except = [];
 
     /**
      * The message bar.
@@ -79,11 +53,10 @@ class VerifyCsrfToken
         MessageBag $messages,
         Redirector $redirector
     ) {
-        $this->except = config('streams::security.csrf.except', []);
+        parent::__construct($app, $encrypter);
 
-        $this->app        = $app;
+        $this->except = config('streams::security.csrf.except', []);
         $this->route      = $route;
-        $this->encrypter  = $encrypter;
         $this->messages   = $messages;
         $this->redirector = $redirector;
     }
@@ -97,42 +70,19 @@ class VerifyCsrfToken
      *
      * @throws \Illuminate\Session\TokenMismatchException
      */
-    public function handle(Request $request, Closure $next)
+    public function handle($request, Closure $next)
     {
-        if (
-            $this->isReading($request) ||
-            $this->runningUnitTests() ||
-            $this->shouldPassThrough() ||
-            $this->inExceptArray($request) ||
-            $this->tokensMatch($request)
-        ) {
+        if ($this->shouldPassThrough()) {
             return $this->addCookieToResponse($request, $next($request));
         }
 
-        $this->messages->error('streams::message.csrf_token_mismatch');
+        try {
+            return parent::handle($request, $next);
+        } catch (TokenMismatchException $exception) {
+            $this->messages->error('streams::message.csrf_token_mismatch');
+        }
 
         return $this->redirector->back(302);
-    }
-
-    /**
-     * Determine if the HTTP request uses a ‘read’ verb.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @return bool
-     */
-    protected function isReading($request)
-    {
-        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
-    }
-
-    /**
-     * Determine if the application is running unit tests.
-     *
-     * @return bool
-     */
-    protected function runningUnitTests()
-    {
-        return $this->app->runningInConsole() && $this->app->runningUnitTests();
     }
 
     /**
@@ -148,79 +98,5 @@ class VerifyCsrfToken
         }
 
         return false;
-    }
-
-    /**
-     * Determine if the request has a URI that should pass through CSRF verification.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @return bool
-     */
-    protected function inExceptArray($request)
-    {
-        foreach ($this->except as $except) {
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if ($request->fullUrlIs($except) || $request->is($except)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if the session and input CSRF tokens match.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @return bool
-     */
-    protected function tokensMatch($request)
-    {
-        $token = $this->getTokenFromRequest($request);
-
-        return is_string($request->session()->token()) &&
-            is_string($token) &&
-            hash_equals($request->session()->token(), $token);
-    }
-
-    /**
-     * Get the CSRF token from the request.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @return string
-     */
-    protected function getTokenFromRequest($request)
-    {
-        $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
-
-        if (!$token && $header = $request->header('X-XSRF-TOKEN')) {
-            $token = $this->encrypter->decrypt($header);
-        }
-
-        return $token;
-    }
-
-    /**
-     * Add the CSRF token to the response cookies.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param  \Symfony\Component\HttpFoundation\Response $response
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function addCookieToResponse($request, $response)
-    {
-        $config = config('session');
-
-        $response->headers->setCookie(
-            new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
-            )
-        );
-
-        return $response;
     }
 }


### PR DESCRIPTION
The addons `VerifyCsrfToken` class was mostly a copy of the Laravel class so it makes more sense to extend the class and add in the Pyro specifics to the extended class. This ensures any fixes that get added to Laravel will get passed through to Pyro in future.