### PR TITLE
Allowed dedicated migrations from app

### DIFF
--- a/src/Database/Migration/Console/Command/ConfigureMigrator.php
+++ b/src/Database/Migration/Console/Command/ConfigureMigrator.php
@@ -71,6 +71,14 @@ class ConfigureMigrator
 
         $this->migrator->setAddon($addon);
 
-        $this->input->setOption('path', $addon->getAppPath('migrations'));
+        $paths = [
+            $addon->getPath('migrations'),
+            $this->command->getLaravel()->databasePath()
+            . DIRECTORY_SEPARATOR.'migrations'
+            . DIRECTORY_SEPARATOR.$addon->getNamespace(),
+        ];
+
+        $this->input->setOption('path', $paths);
+        $this->input->setOption('realpath', true);
     }
 }

--- a/src/Database/Migration/Console/MigrateCommand.php
+++ b/src/Database/Migration/Console/MigrateCommand.php
@@ -34,6 +34,7 @@ class MigrateCommand extends \Illuminate\Database\Console\Migrations\MigrateComm
     protected $signature = 'migrate {--database= : The database connection to use.}
                 {--force : Force the operation to run when in production.}
                 {--path= : The path of migrations files to be executed.}
+                {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
                 {--step : Force the migrations to be run so they can be rolled back individually.}


### PR DESCRIPTION
The current `migration` commands have a problem: when you use it with `--addon` it will ignore all `app` migrations.

If I create a generate module that I customize in the `app`, no migration will checked. It is really troublesome with `php artisan migrate:refresh --addon xx.module.yy` and working with the `app` migrations.

---------------

So I just added the default Laravel migration path + the addon namespace as second path (e.g. `database/migrations/xx.module.yy`).

Also added `realpath` from L5.6 since we are in 5.7.
