### PR TITLE
Dropdown enabled is not working

### DIFF
--- a/resources/lang/fr/addon.php
+++ b/resources/lang/fr/addon.php
@@ -24,6 +24,7 @@ return [
     'enabled'     => 'Activé',
     'disabled'    => 'Désactivé',
     'active'      => 'Actif',
+    'inactive'    => 'Inactif',
     'admin'       => 'Admin',
     'public'      => 'Public'
 ];

--- a/resources/lang/fr/breadcrumb.php
+++ b/resources/lang/fr/breadcrumb.php
@@ -4,5 +4,6 @@ return [
     'login'       => 'Connexion',
     'fields'      => 'Champs',
     'install'     => 'Installation',
+    'revisions'   => 'Révisions',
     'assignments' => 'Assignations',
 ];

--- a/resources/lang/fr/installer.php
+++ b/resources/lang/fr/installer.php
@@ -2,8 +2,11 @@
 
 return [
     'clearing_cache'                 => 'Nettoyage du cache.',
+    'reloading_application'          => 'Rechargement de l\'application.',
     'running_core_migrations'        => 'Installation des migrations du coeur.',
     'running_application_migrations' => 'Installation des migrations des applications.',
     'running_migrations'             => 'Installation des dernières migrations.',
-    'installing'                     => 'Installation : :installing'
+    'running_seeds'                  => 'Installation des injectons de données du projet.',
+    'installing'                     => 'Installation : :installing',
+    'seeding'                        => 'Injecton de données : :seeding',
 ];

--- a/resources/views/buttons/buttons.twig
+++ b/resources/views/buttons/buttons.twig
@@ -44,7 +44,7 @@
 
             {# Render the actual dropdown links #}
             <ul class="dropdown-menu dropdown-menu-{{ button.position }}">
-                {% for link in button.dropdown if link.enabled %}
+                {% for link in button.dropdown if link.enabled is null or link.enabled %}
                     {% if link.text %}
                         <li>
 

--- a/resources/views/buttons/buttons.twig
+++ b/resources/views/buttons/buttons.twig
@@ -44,7 +44,7 @@
 
             {# Render the actual dropdown links #}
             <ul class="dropdown-menu dropdown-menu-{{ button.position }}">
-                {% for link in button.dropdown if link.enabled is null or link.enabled %}
+                {% for link in button.dropdown if link.enabled not false %}
                     {% if link.text %}
                         <li>
 

--- a/resources/views/buttons/buttons.twig
+++ b/resources/views/buttons/buttons.twig
@@ -44,7 +44,7 @@
 
             {# Render the actual dropdown links #}
             <ul class="dropdown-menu dropdown-menu-{{ button.position }}">
-                {% for link in button.dropdown %}
+                {% for link in button.dropdown if link.enabled %}
                     {% if link.text %}
                         <li>
 


### PR DESCRIPTION
When using `enabled` on a button inside a dropdown it will be successfully being removed from the `buttons` list, but not from the parent `$dropdown`. And it will show it. :-(

I think the easiest way is to check directly in the twig.

(Also translated some texts to FR :))