### PR TITLE
Check if .env exists (for Docker / CI)

### DIFF
--- a/src/Application/Command/ReloadEnvironmentFile.php
+++ b/src/Application/Command/ReloadEnvironmentFile.php
@@ -17,7 +17,11 @@ class ReloadEnvironmentFile
      */
     public function handle()
     {
-        foreach (file(base_path('.env'), FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        if (!is_file($file = base_path('.env'))) {
+            return;
+        }
+
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
 
             // Check for # comments.
             if (!starts_with($line, '#')) {


### PR DESCRIPTION
.env may not exists when using Docker or CI (env variable are set using xml or in the interface, e.g. Gitlab).

During `php artisan install --ready` the first `ReloadEnvironmentFile` will be ignored. But the second will work (`env:set` will create it with just a single line).