### PR TITLE
Added card-body for BS4.0+

### DIFF
--- a/resources/views/form/partials/controls.twig
+++ b/resources/views/form/partials/controls.twig
@@ -1,5 +1,5 @@
 <div class="controls {{ position }} {{ form.options.get('section_class', 'card') }}">
-    <div class="card-block">
+    <div class="card-block card-body">
 
         {% if not form.options.read_only %}
             <div class="form__actions actions">

--- a/resources/views/form/partials/default.twig
+++ b/resources/views/form/partials/default.twig
@@ -2,7 +2,7 @@
 
     {% include "streams::form/partials/header" with {"section": section} %}
 
-    <div class="card-block">
+    <div class="card-block card-body">
 
         {% include "streams::form/partials/fields" with {"fields": form.fields.base().pluck('field_name').all()} %}
 

--- a/resources/views/form/partials/heading.twig
+++ b/resources/views/form/partials/heading.twig
@@ -2,7 +2,7 @@
     <div class="card">
 
         {% if form.options.title %}
-            <div class="card-block">
+            <div class="card-block card-body">
                 <h4 class="card-title">
                     {{ trans(form.options.title)|raw }}
 

--- a/resources/views/form/partials/layout.twig
+++ b/resources/views/form/partials/layout.twig
@@ -1,7 +1,7 @@
 {% if form.fields.empty %}
 
     <div class="card">
-        <div class="card-block">
+        <div class="card-block card-body">
             {{ trans("streams::message.no_fields_available") }}
         </div>
     </div>

--- a/resources/views/form/partials/section.twig
+++ b/resources/views/form/partials/section.twig
@@ -4,7 +4,7 @@
 
     {% if section.fields %}
 
-        <div class="card-block">
+        <div class="card-block card-body">
             {% include "streams::form/partials/fields" with {"fields": section.fields} %}
         </div>
 
@@ -20,7 +20,7 @@
 
     {% elseif section.rows %}
 
-        <div class="card-block">
+        <div class="card-block card-body">
             {% include "streams::form/partials/rows" with {"rows": section.rows} %}
         </div>
 

--- a/resources/views/form/partials/tabs.twig
+++ b/resources/views/form/partials/tabs.twig
@@ -11,7 +11,7 @@
     {% endspaceless %}
 </ul>
 
-<div class="card-block">
+<div class="card-block card-body">
     {% for slug, tab in section.tabs %}
         <div class="tab__pane tab-pane {{ loop.first ? ' active' }}" id="tab-{{ form.options.prefix }}{{ tab.slug ?: slug }}">
             {% if tab.view %}

--- a/resources/views/table/partials/heading.twig
+++ b/resources/views/table/partials/heading.twig
@@ -2,7 +2,7 @@
     <div class="card">
 
         {% if table.options.title %}
-            <div class="card-block">
+            <div class="card-block card-body">
                 <h4 class="card-title">
                     {{ trans(table.options.title)|raw }}
 

--- a/resources/views/table/table.twig
+++ b/resources/views/table/table.twig
@@ -47,7 +47,7 @@
 
         {% block no_results %}
             <div class="card">
-                <div class="card-block">
+                <div class="card-block card-body">
                     {{ trans(table.options.get('no_results_message', 'streams::message.no_results')) }}
                 </div>
             </div>

--- a/resources/views/tree/tree.twig
+++ b/resources/views/tree/tree.twig
@@ -13,7 +13,7 @@
             </ul>
         {% else %}
             <div class="card">
-                <div class="card-block">
+                <div class="card-block card-body">
                     {{ trans(tree.options.get('no_results_message', 'streams::message.no_results')) }}
                 </div>
             </div>


### PR DESCRIPTION
The final version of BS4 is using card-body instead of card-block.

I'm using both, so we can start moving on BS4.0+ and keeping the legacy for old themes.