### PR TITLE
Fix FormBuilder to return errors on empty ajax...

### DIFF
--- a/src/Ui/Form/FormBuilder.php
+++ b/src/Ui/Form/FormBuilder.php
@@ -272,7 +272,7 @@ class FormBuilder
         if (app('request')->isMethod('post')) {
             $this->fire('post', ['builder' => $this]);
 
-            if ($this->hasPostData()) {
+            if ($this->hasPostData() || $this->isAjax()) {
                 $this->dispatchNow(new PostForm($this));
             }
         } else {


### PR DESCRIPTION
...requests
This works on non ajax request because of the hidden '_token' field that is usually send via header on ajax requests.