### PR TITLE
Allow nulling of localized values

### DIFF
--- a/src/Ui/Form/Component/Field/FieldFactory.php
+++ b/src/Ui/Form/Component/Field/FieldFactory.php
@@ -80,9 +80,7 @@ class FieldFactory
             $value = array_pull($parameters, 'value');
 
             /* @var EntryInterface $entry */
-            $field->setValue(
-                (!is_null($value)) ? $modifier->restore($value) : $entry->getAttribute($field->getField())
-            );
+            $field->setValue($modifier->restore($value));
         } elseif (is_object($entry)) {
             $field    = $this->builder->build($parameters);
             $modifier = $field->getModifier();

--- a/src/Ui/Form/Component/Field/FieldPopulator.php
+++ b/src/Ui/Form/Component/Field/FieldPopulator.php
@@ -63,7 +63,8 @@ class FieldPopulator
              */
             if (!isset($field['value']) && $entry instanceof EloquentModel && $entry->getId()) {
                 if ($locale = array_get($field, 'locale')) {
-                    $field['value'] = $entry->translateOrDefault($locale)->{$field['field']};
+                    $field['value'] = $entry->translateOrDefault($locale)
+                        ->getAttribute($field['field']);
                 } else {
                     $field['value'] = $entry->{$field['field']};
                 }


### PR DESCRIPTION
> I suspect you may not want to take this since it changes the behavior of localized fields kinda dramatically, but maybe it'll help someone else...

For some field types (textfields, files) but not others (wysiwyg, booleans), if you clear the value of a field and save, Pyro saves a `null` to the database for the value of that translated field which is fine.  However, when Pyro renders the form next, instead of showing an empty field for that locale, it renders the value of the fallback locale.  I believe that Pyro _should_ continue to show the empty field so that content admins can remove field values for some locales.  

A use case would be a field for a phone number where some locales don't have a phone number.