### PR TITLE
Auto register factories for CLI

### DIFF
--- a/resources/config/countries.php
+++ b/resources/config/countries.php
@@ -236,7 +236,8 @@ return [
             'name' => 'Faroe Islands',
         ],
         'FR' => [
-            'name' => 'France',
+            'name'         => 'France',
+            'calling_code' => 33,
         ],
         'GA' => [
             'name' => 'Gabon',
@@ -660,7 +661,8 @@ return [
             'name' => 'Togo',
         ],
         'TH' => [
-            'name' => 'Thailand',
+            'name'         => 'Thailand',
+            'calling_code' => 66,
         ],
         'TJ' => [
             'name' => 'Tajikistan',

--- a/src/Addon/AddonProvider.php
+++ b/src/Addon/AddonProvider.php
@@ -240,7 +240,7 @@ class AddonProvider
      */
     protected function registerFactories(Addon $addon)
     {
-        if (env('APP_ENV') == 'testing' && is_dir($factories = $addon->getPath('factories'))) {
+        if ($this->application->runningInConsole() && is_dir($factories = $addon->getPath('factories'))) {
             app(Factory::class)->load($factories);
         }
     }


### PR DESCRIPTION
Because currently factories cannot be using in `php artisan db:seed`.

+ some calling codes as extra