### PR TITLE
Fix ambiguous sort_order column bug

### DIFF
--- a/src/Model/EloquentQueryBuilder.php
+++ b/src/Model/EloquentQueryBuilder.php
@@ -278,7 +278,7 @@ class EloquentQueryBuilder extends Builder
                 $query->orderBy('streams_streams.sort_order', 'ASC');
             } elseif ($model instanceof EntryInterface) {
                 if ($model->getStream()->isSortable()) {
-                    $query->orderBy('sort_order', 'ASC');
+                    $query->orderBy($model->getTable() . '.sort_order', 'ASC');
                 } elseif ($model->titleColumnIsTranslatable()) {
 
                     /**

--- a/src/Model/EloquentTableRepository.php
+++ b/src/Model/EloquentTableRepository.php
@@ -123,7 +123,7 @@ class EloquentTableRepository implements TableRepositoryInterface
         }
 
         if ($builder->getTableOption('sortable')) {
-            $query = $query->orderBy('sort_order', 'ASC');
+            $query = $query->orderBy($this->model->getTable() . '.sort_order', 'ASC');
         }
 
         $builder->fire('queried', compact('builder', 'query'));


### PR DESCRIPTION
Prevents ambiguous order clause due to the sort_order columns on two tables being joined in an eloquent find.

Fixes https://github.com/pyrocms/pyrocms/issues/4981.