### PR TITLE
fix php 7.3 support

### DIFF
--- a/src/Http/Controller/AssignmentsController.php
+++ b/src/Http/Controller/AssignmentsController.php
@@ -73,7 +73,7 @@ class AssignmentsController extends AdminController
             ->notAssignedTo($stream)
             ->unlocked();
 
-        return $this->view->make('streams::assignments/choose', compact('fields', 'group', 'module'));
+        return $this->view->make('streams::assignments/choose', compact('fields', 'module'));
     }
 
     /**


### PR DESCRIPTION
compact() now issues an E_NOTICE level error if a given string refers to an unset variable. Formerly, such strings have been silently skipped. 

Don't know why group was even there?!