### PR TITLE
Fixed config override for addons

### DIFF
--- a/src/Addon/AddonIntegrator.php
+++ b/src/Addon/AddonIntegrator.php
@@ -152,6 +152,7 @@ class AddonIntegrator
                     . $addon->getVendor() . '/'
                     . $addon->getSlug() . '-'
                     . $addon->getType()
+                    . '/config'
                 )
             );
         }


### PR DESCRIPTION
The current config path is `resources/addons/namespace/addon-type` instead of `resources/addons/namespace/addon-type/config`.

And it will break if we override something else (like the views `resources/addons/namespace/addon-type/views`). Because it will try to load all the `.twig` as PHP config files. ^^;