### PR TITLE
Flag to make a section a heading only

### DIFF
--- a/src/Ui/ControlPanel/Component/Section/Section.php
+++ b/src/Ui/ControlPanel/Component/Section/Section.php
@@ -131,7 +131,37 @@ class Section implements SectionInterface
      * @var bool
      */
     protected $hidden = false;
+    
+    /**
+     * Heading Flag
+     *
+     * @var bool
+     */
+    protected $heading_only = false;
 
+    /**
+     * Get the heading_only flag.
+     *
+     * @return boolean
+     */
+    public function isHeadingOnly()
+    {
+        return $this->heading_only;
+    }
+
+    /**
+     * Set the heading_only.
+     *
+     * @param $heading_only
+     * @return $this
+     */
+    public function setHeadingOnly($flag)
+    {
+        $this->heading_only = $flag;
+
+        return $this;
+    }
+    
     /**
      * Get the slug.
      *


### PR DESCRIPTION
Puts an element on a section so the that navigation can have sub menu items, without itself being a link.

This goes with another PR for accelerant theme: https://github.com/pyrocms/accelerant-theme/pull/47