### PR TITLE
Currency formatting

### DIFF
--- a/src/Support/Currency.php
+++ b/src/Support/Currency.php
@@ -40,7 +40,7 @@ class Currency
         $point     = array_get(
             $options,
             'point',
-            config('streams::currencies.supported.' . $currency . '.point' . '.')
+            config('streams::currencies.supported.' . $currency . '.point', '.')
         );
 
         $prefix = null;
@@ -80,7 +80,7 @@ class Currency
         $point     = array_get(
             $options,
             'point',
-            config('streams::currencies.supported.' . $currency . '.point' . '.')
+            config('streams::currencies.supported.' . $currency . '.point', '.')
         );
 
         return number_format(floor(($number * 100)) / 100, $decimals, $point, $separator);


### PR DESCRIPTION
My custom `point` character was not working.
Digging deeper I've found out it's not being read correctly from the config. I've encountered a typo-like error when formatting currency and here's a fix.