### PR TITLE
Remove run method from seeder to allow dependency injection again

### DIFF
--- a/src/Database/Seeder/Seeder.php
+++ b/src/Database/Seeder/Seeder.php
@@ -37,12 +37,4 @@ class Seeder extends \Illuminate\Database\Seeder
         $this->streams     = app(StreamRepositoryInterface::class);
         $this->assignments = app(AssignmentRepositoryInterface::class);
     }
-
-    /**
-     * Run the seeder.
-     */
-    public function run()
-    {
-        # code...
-    }
 }


### PR DESCRIPTION
default laravel seeder allows dependency injection with the `run()` method. 

Pyrocms overrides this. Resulting in:

`Declaration should be compatible with Seeder->run()`