### PR TITLE
Fixed remote asset on non root hosting

### DIFF
--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -323,6 +323,10 @@ class Asset
             $this->add($collection, $collection, $filters, true);
         }
 
+        if (starts_with($collection, ['http', '//'])) {
+            $basePath = false;
+        }
+
         return ($basePath ? request()->getBasePath() : '') . $this->getPath($collection, $filters);
     }
 


### PR DESCRIPTION
When the app is not hosted directly on the root of a domain (e.g. `www.domain.com/app`), and we add external assets (e.g. `asset_add('scripts.js', 'https://cdn.domaine.com/js/some.js')`) the return path will fail.

`asset_paths('scripts.js')` will return `apphttps://cdn.domaine.com/js/some.js`.