### PR TITLE
Fixing url singleton

### DIFF
--- a/src/StreamsServiceProvider.php
+++ b/src/StreamsServiceProvider.php
@@ -206,11 +206,11 @@ class StreamsServiceProvider extends ServiceProvider
         $this->dispatchNow(new ConfigureFileCacheStore());
         $this->dispatchNow(new ConfigureTranslator());
         $this->dispatchNow(new AutoloadEntryModels());
+        $this->overrideUrlSingleton();
         $this->dispatchNow(new AddAssetNamespaces());
         $this->dispatchNow(new AddImageNamespaces());
         $this->dispatchNow(new ConfigureRequest());
         $this->dispatchNow(new ConfigureScout());
-        $this->overrideUrlSingleton();
 
         // Observe our base models.
         EntryModel::observe(EntryObserver::class);

--- a/src/StreamsServiceProvider.php
+++ b/src/StreamsServiceProvider.php
@@ -91,7 +91,6 @@ class StreamsServiceProvider extends ServiceProvider
      */
     public $bindings = [
         'Illuminate\Contracts\Debug\ExceptionHandler'                                    => 'Anomaly\Streams\Platform\Exception\ExceptionHandler',
-        'Illuminate\Routing\UrlGenerator'                                                => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
         'Illuminate\Database\Migrations\MigrationRepositoryInterface'                    => 'Anomaly\Streams\Platform\Database\Migration\MigrationRepository',
         'Anomaly\Streams\Platform\Entry\EntryModel'                                      => 'Anomaly\Streams\Platform\Entry\EntryModel',
         'Anomaly\Streams\Platform\Entry\Contract\EntryRepositoryInterface'               => 'Anomaly\Streams\Platform\Entry\EntryRepository',

--- a/src/StreamsServiceProvider.php
+++ b/src/StreamsServiceProvider.php
@@ -92,7 +92,6 @@ class StreamsServiceProvider extends ServiceProvider
     public $bindings = [
         'Illuminate\Contracts\Debug\ExceptionHandler'                                    => 'Anomaly\Streams\Platform\Exception\ExceptionHandler',
         'Illuminate\Routing\UrlGenerator'                                                => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
-        'Illuminate\Contracts\Routing\UrlGenerator'                                      => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
         'Illuminate\Database\Migrations\MigrationRepositoryInterface'                    => 'Anomaly\Streams\Platform\Database\Migration\MigrationRepository',
         'Anomaly\Streams\Platform\Entry\EntryModel'                                      => 'Anomaly\Streams\Platform\Entry\EntryModel',
         'Anomaly\Streams\Platform\Entry\Contract\EntryRepositoryInterface'               => 'Anomaly\Streams\Platform\Entry\EntryRepository',
@@ -124,7 +123,6 @@ class StreamsServiceProvider extends ServiceProvider
      */
     public $singletons = [
         'Illuminate\Database\Migrations\Migrator'                                            => 'Anomaly\Streams\Platform\Database\Migration\Migrator',
-        'Illuminate\Contracts\Routing\UrlGenerator'                                          => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
         'Anomaly\Streams\Platform\Routing\UrlGenerator'                                      => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
         'Intervention\Image\ImageManager'                                                    => 'image',
         'League\Flysystem\MountManager'                                                      => 'League\Flysystem\MountManager',

--- a/src/StreamsServiceProvider.php
+++ b/src/StreamsServiceProvider.php
@@ -122,7 +122,7 @@ class StreamsServiceProvider extends ServiceProvider
      */
     public $singletons = [
         'Illuminate\Database\Migrations\Migrator'                                            => 'Anomaly\Streams\Platform\Database\Migration\Migrator',
-        'Anomaly\Streams\Platform\Routing\UrlGenerator'                                      => 'Anomaly\Streams\Platform\Routing\UrlGenerator',
+        'Anomaly\Streams\Platform\Routing\UrlGenerator'                                      => 'url',
         'Intervention\Image\ImageManager'                                                    => 'image',
         'League\Flysystem\MountManager'                                                      => 'League\Flysystem\MountManager',
         'Illuminate\Database\Seeder'                                                         => 'Anomaly\Streams\Platform\Database\Seeder\Seeder',


### PR DESCRIPTION
`StreamsServiceProvider` is binding and singleton `Illuminate\Contracts\Routing\UrlGenerator` to `Anomaly\Streams\Platform\Routing\UrlGenerator`.

The problem is than in Laravel, `Illuminate\Contracts\Routing\UrlGenerator` is supposed to be an alias of `url`. And we now have 2 completely different `UrlGenerator`.

* Everything using `app('url')` (and so URL facade) is using `\Illuminate\Routing\UrlGenerator`
* Everything using `app(\Illuminate\Contracts\Routing\UrlGenerator::class)` (and `Illuminate\Routing\UrlGenerator`) is using `Anomaly\Streams\Platform\Routing\UrlGenerator`.

Also everything using `Illuminate\Contracts\Routing\UrlGenerator` will have no rebinding added to `url` inside `RoutingServiceProvider`. For example, changing the routes in a Test doesn't  work (`\Illuminate\Contracts\Routing\UrlGenerator::class` has no request rebinding and will use first binded Request, so `/` everywhere).

-----------------

We cannot just remove  the binding/singleton because `url` will use Laravel `UrlGenerator`. So it need to be rebinded.  I also binded the singleton of `Anomaly\Streams\Platform\Routing\UrlGenerator` to `url`.

----------------

So now `url`, `Illuminate\Contracts\Routing\UrlGenerator`, `Illuminate\Routing\UrlGenerator`, `Anomaly\Streams\Platform\Routing\UrlGenerator` will return the same object of `Anomaly\Streams\Platform\Routing\UrlGenerator`.

Tested on custom Laravel using SP 1.6 and on fresh Pyro 3.7.