### PR TITLE
IconRegistry::register argument fix

### DIFF
--- a/src/Ui/Icon/IconRegistry.php
+++ b/src/Ui/Icon/IconRegistry.php
@@ -172,13 +172,13 @@ class IconRegistry
     /**
      * Register an icon.
      *
-     * @param        $icon
-     * @param  array $parameters
+     * @param  string $icon
+     * @param  string $value
      * @return $this
      */
-    public function register($icon, array $parameters)
+    public function register($icon, $value)
     {
-        array_set($this->icons, $icon, $parameters);
+        array_set($this->icons, $icon, $value);
 
         return $this;
     }


### PR DESCRIPTION
Change argument to allow any value to be assigned to an icon.… This make it possible to assign a string as value as that is the appropriate value instead of an array

The problem:
```php
class IconRegistry
{
    protected $icons = [
        'addon'                => 'fa fa-puzzle-piece',
        'adjust'               => 'glyphicons glyphicons-adjust-alt',
        'airplane'             => 'glyphicons glyphicons-airplane',
        'amex'                 => 'fa fa-cc-amex',
        // ...
    ];

    public function register($icon, array $parameters)
    {
        # we can only set array, not strings as should be
        array_set($this->icons, $icon, $parameters);
        return $this;
    }
}
```

[The fix](686/files)