### PR TITLE
Adding custom logic and features to providers by using more callbacks and macroable

### DIFF
--- a/src/Addon/AddonProvider.php
+++ b/src/Addon/AddonProvider.php
@@ -6,6 +6,7 @@ use Anomaly\Streams\Platform\Addon\Extension\Extension;
 use Anomaly\Streams\Platform\Addon\Module\Module;
 use Anomaly\Streams\Platform\Addon\Theme\Theme;
 use Anomaly\Streams\Platform\Http\Middleware\MiddlewareCollection;
+use Anomaly\Streams\Platform\Traits\FiresCallbacks;
 use Anomaly\Streams\Platform\View\Event\RegisteringTwigPlugins;
 use Anomaly\Streams\Platform\View\ViewMobileOverrides;
 use Anomaly\Streams\Platform\View\ViewOverrides;
@@ -16,6 +17,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Traits\Macroable;
 
 /**
  * Class AddonProvider
@@ -26,6 +28,8 @@ use Illuminate\Routing\Router;
  */
 class AddonProvider
 {
+    use Macroable;
+    use FiresCallbacks;
 
     /**
      * The cached services.
@@ -143,6 +147,8 @@ class AddonProvider
 
         $this->providers[] = $provider = $addon->newServiceProvider();
 
+        $this->fire('register', [ 'provider' => $provider, 'addon' => $addon, 'addonProvider' => $this ]);
+
         $this->bindAliases($provider);
         $this->bindClasses($provider);
         $this->bindSingletons($provider);
@@ -167,6 +173,8 @@ class AddonProvider
 
         // Call other providers last.
         $this->registerProviders($provider);
+
+        $this->fire('registered', [ 'provider' => $provider, 'addon' => $addon, 'addonProvider' => $this ]);
     }
 
     /**

--- a/src/Addon/AddonServiceProvider.php
+++ b/src/Addon/AddonServiceProvider.php
@@ -6,6 +6,7 @@ use Anomaly\Streams\Platform\Addon\Plugin\Plugin;
 use Anomaly\Streams\Platform\Addon\Theme\Theme;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Traits\Macroable;
 
 /**
  * Class AddonServiceProvider
@@ -16,7 +17,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
  */
 class AddonServiceProvider
 {
-
+    use Macroable;
     use DispatchesJobs;
 
     /**

--- a/src/Traits/FiresCallbacks.php
+++ b/src/Traits/FiresCallbacks.php
@@ -49,6 +49,24 @@ trait FiresCallbacks
      * @param $callback
      * @return $this
      */
+    public static function when($trigger, $callback)
+    {
+        $trigger = static::class . '::' . $trigger;
+
+        if ( ! isset(self::$listeners[ $trigger ])) {
+            self::$listeners[ $trigger ] = [];
+        }
+
+        self::$listeners[ $trigger ][] = $callback;
+    }
+
+    /**
+     * Register a new listener.
+     *
+     * @param $trigger
+     * @param $callback
+     * @return $this
+     */
     public function listen($trigger, $callback)
     {
         $trigger = get_class($this) . '::' . $trigger;


### PR DESCRIPTION
AddonServiceProvider has some handy properties to define and register stuff. The `aliases`, `plugins`, `routes` and them other properties. But i could personally think of a bunch more for my own application that i'd like to add. But to achieve that, i'd have to do stuff i would much rather not.

If i want to add some custom logic, lets say `components`
```php
protected $components = [
    'cool::component' => MyCoolComponent::class
];
```

**First problem to tackle** 
I got a few choices, none of them attractive:
- Extend `AddonServiceProvider` and to `RadicAddonServiceProvider` and use that for my addons
- Use composer to override `vendor/anomaly/streams-platform/src/Addon/AddonServiceProvider.php`  to my own copy of `AddonServiceProvider` (using a combination of `autoload.psr4` and `autoload.exclude-from-classmap`). 

**Second problem to tackle** 
The `AddonProvider` handles the property logic in `AddonServiceProvider`. Again a few choices:
- Extend `AddonProvider` and bind my version it in the `Container`
- Use composer like above


**Possible solution**
So here's my take on this. Using `Macroable` and `FiresCallback` as this commit does, to make it possible to define it like this:
```php
AddonServiceProvider::macro('getComponents', function(){
    if(property_exists(get_class($this),'components') && $this->components !== null){
        return $this->components;
    }
    return [];
});
AddonProvider::when('registered', function (AddonServiceProvider $provider, Addon $addon) {
    foreach ($provider->getComponents() as $id => $class) {
        app()->make('my-awesome-components-registry')->register($id, $class);
    }
});
```

Which makes this code work perfectly
```php
class SuperDuperAwesomeModuleServiceProvider extends AddonServiceProvider {
    protected $components = [
        'cool::component' => MyCoolComponent::class
    ];
}
```

I obviously know you are working/thinking about changing this logic completely for 4.0. But it would be really great to get this in for 3.7