### PR TITLE
Hide dropdown buttons we don't have permission to use.

### DIFF
--- a/src/Ui/Table/Component/Button/ButtonDropdown.php
+++ b/src/Ui/Table/Component/Button/ButtonDropdown.php
@@ -51,7 +51,7 @@ class ButtonDropdown
         $authorizer = resolve(Authorizer::class);
 
         foreach ($buttons as $key => &$button) {
-            if (!$authorizer->authorize($button['permission'])) {
+            if (isset($button['permission']) && !$authorizer->authorize($button['permission'])) {
                 // We don't have permission to use this button so hide it
                 continue;
             }

--- a/src/Ui/Table/Component/Button/ButtonDropdown.php
+++ b/src/Ui/Table/Component/Button/ButtonDropdown.php
@@ -1,5 +1,6 @@
 <?php namespace Anomaly\Streams\Platform\Ui\Table\Component\Button;
 
+use Anomaly\Streams\Platform\Support\Authorizer;
 use Anomaly\Streams\Platform\Ui\Table\TableBuilder;
 
 /**
@@ -47,8 +48,14 @@ class ButtonDropdown
     public function build(TableBuilder $builder)
     {
         $buttons = $builder->getButtons();
+        $authorizer = resolve(Authorizer::class);
 
         foreach ($buttons as $key => &$button) {
+            if (!$authorizer->authorize($button['permission'])) {
+                // We don't have permission to use this button so hide it
+                continue;
+            }
+
             if ($dropdown = array_get($button, 'parent')) {
                 foreach ($buttons as &$parent) {
                     if (array_get($parent, 'button') == $dropdown) {


### PR DESCRIPTION
Currently the dropdown buttons are shown and link to a page that errors with a 403 status. To prevent confusion for end users, the dropdown button is now hidden. This is configured using the existing `permission` key in the buttons array.