### PR TITLE
Should use ttl as ttl :)

### DIFF
--- a/src/Http/CacheKernel.php
+++ b/src/Http/CacheKernel.php
@@ -82,7 +82,7 @@ class CacheKernel extends \Barryvdh\HttpCache\CacheKernel
         /**
          * Disable for Control Panel
          */
-        if (str_is(self::$excluded, $_SERVER['REQUEST_URI']) || in_array($_SERVER['HTTP_HOST'], $domains)) {
+        if (str_is(static::$excluded, $_SERVER['REQUEST_URI']) || in_array($_SERVER['HTTP_HOST'], $domains)) {
             return $kernel;
         }
 

--- a/src/Http/Middleware/HttpCache.php
+++ b/src/Http/Middleware/HttpCache.php
@@ -164,7 +164,7 @@ class HttpCache
         /**
          * Determine the default TTL value.
          */
-        $default = $route->getAction('streams::http_cache') ?: config('streams::httpcache.ttl', 3600);
+        $default = $route->getAction('ttl') ?: config('streams::httpcache.ttl', 3600);
 
         /**
          * Exclude these paths from caching


### PR DESCRIPTION
Well, it's using `$route->getAction('streams::http_cache')` everywhere excepted here.