### PR TITLE
support secure cookie

### DIFF
--- a/src/Http/Middleware/ProxySession.php
+++ b/src/Http/Middleware/ProxySession.php
@@ -33,7 +33,7 @@ class ProxySession
 
         if (method_exists($response, 'withCookie')) {
             return $response->withCookie(
-                cookie('session_proxy', $check, $check ? config('session.lifetime', 120) : -1, null, null, env('SESSION_SECURE_COOKIE', true))
+                 cookie('session_proxy', $check, $check ? config('session.lifetime', 120) : -1, null, null, $request->isSecure())
             );
         }
 

--- a/src/Http/Middleware/ProxySession.php
+++ b/src/Http/Middleware/ProxySession.php
@@ -33,7 +33,7 @@ class ProxySession
 
         if (method_exists($response, 'withCookie')) {
             return $response->withCookie(
-                cookie('session_proxy', $check, $check ? config('session.lifetime', 120) : -1)
+                cookie('session_proxy', $check, $check ? config('session.lifetime', 120) : -1, null, null, env('SESSION_SECURE_COOKIE', true))
             );
         }
 


### PR DESCRIPTION
Set the cookie as secure by default as best practice, but allow override for non ssl devs if wanted.