### PR TITLE
Use `getFieldValue` for translated relationship attributes.

### DIFF
--- a/src/Entry/EntryModel.php
+++ b/src/Entry/EntryModel.php
@@ -428,8 +428,12 @@ class EntryModel extends EloquentModel implements EntryInterface, PresentableInt
     public function getAttribute($key)
     {
 
-        // Check if it's a relationship first.
-        if (in_array($key, array_merge($this->relationships, ['created_by', 'updated_by']))) {
+        // Check if it's a relationship first. Ignore translated relationships as these
+        // end up being handled by the field type anyway.
+        if (
+            in_array($key, array_merge($this->relationships, ['created_by', 'updated_by']))
+            && !in_array($key, $this->translatedAttributes)
+        ) {
             return parent::getAttribute(camel_case($key));
         }
 


### PR DESCRIPTION
Skip trying to get the translated relationship using the laravel relationships as this ends in an error if the translated value is empty. It errors when serialising because it doesn't check for the `_id` field on the translation table, only the field slug. It also errors if a value is null as it tries to return the field from the parent using the original slug. 

Skipping this and going straight through `getFieldValue` will return the relationship id properly which is what currently happens if the translated values are present. This has the added benefit of fetching the default translated value (e.g. for `en`) if a translation for the current locale is not available.

Unless there's a better way to use translated relationships that I'm not aware of, this fix allows us to use the feature and work around the relationship issues by using a presenter to fetch the related model by its id.