### PR TITLE
Use custom lexer to avoid minified CSS breaking twig comments in parse

### DIFF
--- a/docs/en/01.prologue/02.change-log.md
+++ b/docs/en/01.prologue/02.change-log.md
@@ -28,6 +28,9 @@ Features that are deprecated will generally be removed in the next `minor` updat
 
 ## Releases
 
+### [1.7.34] - 2020-07-07
+- Modified the `parse` filter in `Asset` to allow for minified CSS to be parsed (such as from Laravel Mix).
+
 ### [1.7.33] - 2020-07-04
 - Added a deprecated CacheConfig in the correct PSR-4 autoloading location for backwards compatibility in `anomaly/settings-module`.
 

--- a/docs/en/12.front-end-development/03.assets.md
+++ b/docs/en/12.front-end-development/03.assets.md
@@ -91,7 +91,7 @@ $asset->add("collection.css", "theme::example.scss", ["min", "live"]);
 - `less`: parses LESS into CSS
 - `styl`: parses STYL into CSS
 - `scss`: parses SCSS into CSS
-- `parse`: parses content with Twig
+- `parse`: parses content with Twig. Uses an alternate comment syntax `{* *}` to prevent clashes with CSS selectors.
 - `coffee`: compiles CoffeeScript into Javascript
 - `embed`: embeds image data in your stylesheets
 - `live`: refreshes content when LIVE_ASSETS is enabled

--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -574,6 +574,15 @@ class Asset
          * Parse the content. Always parse CSS.
          */
         if (in_array('parse', $filters) || $hint == 'css') {
+            /** @var Bridge $twig */
+            $twig = resolve('twig');
+
+            $twig->setLexer(
+                new \Twig_Lexer($twig, [
+                    'tag_comment' => ['{*', '*}']
+                ])
+            );
+
             try {
                 $contents = $this->template
                     ->render($contents)
@@ -586,6 +595,12 @@ class Asset
 
                 \Log::error($e->getMessage());
             }
+
+            $twig->setLexer(
+                new \Twig_Lexer($twig, [
+                    'tag_comment' => ['{#', '#}']
+                ])
+            );
         }
 
         /**

--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -579,7 +579,7 @@ class Asset
 
             $twig->setLexer(
                 new \Twig_Lexer($twig, [
-                    'tag_comment' => ['{*', '*}']
+                    'tag_comment' => ['{^', '^}']
                 ])
             );
 


### PR DESCRIPTION
This prevents an issue where minified CSS (usually produced by Mix) with any media queries (resulting in a line such as `@media (max-width:768px){#example{}}`) that was run through the `parse` filter would result in the "Unclosed comment" issue, which will break the page.