### PR TITLE
Fixed php7.4 notice on parsedown-extra

### DIFF
--- a/src/Support/Markdown.php
+++ b/src/Support/Markdown.php
@@ -53,7 +53,11 @@ class Markdown extends \ParsedownExtra
      */
     protected function inlineLink($excerpt)
     {
-        $link = parent::inlineLink($excerpt);
+        try {
+            $link = parent::inlineLink($excerpt);
+        } catch (\ErrorException $e) {
+            return;
+        }
 
         if (!isset($link['element']['text'][0])) {
             return $link;


### PR DESCRIPTION
`parsedown-extra` with PHP7.4 is broken if you are using `[` symbol (w/o closing it).

```php
$remainder = substr($Excerpt['text'], $Link['extent']);
```

`$Link` is currently `null`, but PHP7.4 will now throw a notice... so it crash.

> Trying to use values of type null, bool, int, float or resource as an array (such as $null["key"]) will now generate a notice.

 It's fixed in 0.8, but it looks like they changed how it's working, so I just do a `catch` to manage that.