### PR TITLE
Fixed MultiLanguage Problems

### DIFF
--- a/src/Model/EloquentQueryBuilder.php
+++ b/src/Model/EloquentQueryBuilder.php
@@ -361,7 +361,10 @@ class EloquentQueryBuilder extends Builder
                 )
         );
 
-        $this->query->groupBy([$model->getTableName() . '.id', $model->getTranslationsTableName() . '.id']);
+        /**
+         * removed to prevent data repeatation( getTranslationsTableName() )
+         */
+        $this->query->groupBy([$model->getTableName() . '.id']);
 
         /**
          * Grab either what matches or null because
@@ -369,8 +372,9 @@ class EloquentQueryBuilder extends Builder
          */
         $this->query->where(
             function (\Illuminate\Database\Query\Builder $query) use ($model, $locale) {
-                $query->where($model->getTranslationsTableName() . '.locale', $locale ?: config('app.locale'));
-                $query->orWhereNull($model->getTranslationsTableName() . '.locale');
+                $query->where($model->getTranslationsTableName() . '.locale', $locale ?: config('app.locale'));//active language
+                $query->orWhere($model->getTranslationsTableName() . '.locale',setting_value('streams::default_locale'));//or default setting language
+                $query->orWhere($model->getTranslationsTableName() . '.locale','en');//or default module language
             }
         );
 


### PR DESCRIPTION
getTranslationsTableName() removed to prevent data repeatation.The default addon language has been added for languages ​​that are not active in the system.

@fatihalp