### PR TITLE
Fixes typo in how to get a form for manual rendering

### DIFF
--- a/docs/en/12.front-end-development/07.forms.md
+++ b/docs/en/12.front-end-development/07.forms.md
@@ -23,7 +23,7 @@ The `render` method will trigger display but it is optional as `__toString` will
 You may want to take more control and set the form to a variable and use it.
 
 ```twig
-{% set form = form('books', 'reviews') %}
+{% set form = form('books', 'reviews').get() %}
 
 {{ form.open|raw }}
 


### PR DESCRIPTION
Error "Method Anomaly\Streams\Platform\Ui\Form\FormCriteria::__toString() must not throw an exception" is thrown if `.get()` is omitted