### PR TITLE
Fixes theme creation

### DIFF
--- a/src/Addon/AddonLoader.php
+++ b/src/Addon/AddonLoader.php
@@ -121,7 +121,7 @@ class AddonLoader
      */
     public function dump()
     {
-        $process = new Process('composer dump-autoload');
+        $process = new Process(['composer', 'dump-autoload']);
 
         $process->run();
         $process->wait();


### PR DESCRIPTION
Symfony takes command line arrays in the 'Process' class instead of string (since 3.3.0)

Theme creation `php artisan make:addon behavior_lab.theme.default` failed when it came to running `composer dump-autoload` with the following message:

```
Addon [behavior_lab.theme.default] created.

In Process.php line 140:
  Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in .../vendor/anomaly/streams-platform/src/Addon/AddonLoader.php on line 124
```