### PR TITLE
Fixed bug that prevent installing. Changed the string argument to array

### DIFF
--- a/src/Addon/AddonLoader.php
+++ b/src/Addon/AddonLoader.php
@@ -121,7 +121,7 @@ class AddonLoader
      */
     public function dump()
     {
-        $process = new Process('composer dump-autoload');
+        $process = new Process(['composer dump-autoload']);
 
         $process->run();
         $process->wait();


### PR DESCRIPTION
```
1/63 Running core migrations.
2/63 Running application migrations.
3/63 Installing: Dashboard Module
4/63 Installing: Configuration Module
5/63 Installing: Blocks Module
6/63 Installing: Addons Module
7/63 Installing: Preferences Module
8/63 Installing: Repeaters Module
9/63 Installing: Settings Module
10/63 Installing: Pages Module
11/63 Installing: Streams Module
12/63 Installing: Posts Module
13/63 Installing: Variables Module
14/63 Installing: Search Module
15/63 Installing: Files Module
16/63 Installing: System Module
17/63 Installing: Users Module
18/63 Installing: Navigation Module
19/63 Installing: Redirects Module
20/63 Installing: Default Authenticator Extension
21/63 Installing: Default Page Handler Extension
22/63 Installing: Page Link Type
23/63 Installing: Robots Extension
24/63 Installing: User Security Check Extension
25/63 Installing: Private Storage Adapter Extension
26/63 Installing: WYSIWYG Block Extension
27/63 Installing: HTML Block Extension
28/63 Installing: Throttle Security Check Extension
29/63 Installing: URL Link Type Extension
30/63 Installing: XML Feed Dashboard Widget
31/63 Installing: Sitemap Extension
32/63 Reloading application.

In Process.php line 140:
                                                                                                                                                                                                                              
  Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in /home/radic/projects/pyro38/vendor/anomaly/streams-platform/src/Addon/AddonLoader.php on line 124  
    
```