### PR TITLE
Replace Linkify by Url highlight

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/yaml": "3.4.*",
         "jenssegers/agent": "2.6.*",
         "asm89/twig-cache-extension": "1.3.*",
-        "misd/linkify": "1.1.*",
+        "vstelmakh/url-highlight": "^2.2",
         "ezyang/htmlpurifier": "~4.0",
         "barryvdh/laravel-httpcache": "^0.3.0",
         "tubalmartin/cssmin": "~4.0",

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -1,6 +1,8 @@
 <?php namespace Anomaly\Streams\Platform\Support;
 
-use Misd\Linkify\Linkify;
+use VStelmakh\UrlHighlight\Encoder\HtmlSpecialcharsEncoder;
+use VStelmakh\UrlHighlight\Highlighter\HtmlHighlighter;
+use VStelmakh\UrlHighlight\UrlHighlight;
 
 /**
  * Class Str
@@ -67,7 +69,10 @@ class Str extends \Illuminate\Support\Str
      */
     public function linkify($text, array $options = [])
     {
-        return (new Linkify($options))->process($text);
+        $encoder = new HtmlSpecialcharsEncoder();
+        $highlighter = new HtmlHighlighter('http', $options['attr']);
+        $urlHighlight = new UrlHighlight(null, $highlighter, $encoder);
+        return $urlHighlight->highlightUrls($text);
     }
 
     /**

--- a/tests/Unit/Support/StrTest.php
+++ b/tests/Unit/Support/StrTest.php
@@ -12,4 +12,54 @@ class StrTest extends TestCase
     {
         $this->assertEquals('Ryan...', (new \Anomaly\Streams\Platform\Support\Str())->truncate('Ryan Thompson', 7));
     }
+
+    /**
+     * @dataProvider linkifyDataProvider
+     */
+    public function testLinkify(string $text, array $attributes, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new \Anomaly\Streams\Platform\Support\Str())->linkify($text, ['attr' => $attributes])
+        );
+    }
+
+    /**
+     * @return array[]
+     */
+    public function linkifyDataProvider(): array
+    {
+        return [
+            'one url' => [
+                'Some http://example.com text',
+                [],
+                'Some <a href="http://example.com">http://example.com</a> text',
+            ],
+            'two urls' => [
+                'Visit http://example.com, and see some example.com content.',
+                [],
+                'Visit <a href="http://example.com">http://example.com</a>, and see some <a href="http://example.com">example.com</a> content.',
+            ],
+            'html special chars encoded' => [
+                'Some &lt;b&gt;http://example.com&lt;/b&gt; text',
+                [],
+                'Some &lt;b&gt;<a href="http://example.com">http://example.com</a>&lt;/b&gt; text',
+            ],
+            'already highlighted' => [
+                'Some <a href="http://example.com">http://example.com</a> text',
+                [],
+                'Some <a href="http://example.com">http://example.com</a> text',
+            ],
+            'email' => [
+                'Some user@example.com text',
+                [],
+                'Some <a href="mailto:user@example.com">user@example.com</a> text',
+            ],
+            'attributes' => [
+                'Some http://example.com text',
+                ['target' => '_blank'],
+                'Some <a href="http://example.com" target="_blank">http://example.com</a> text',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Suggestion to replace Linkify by [Url highlight](https://github.com/vstelmakh/url-highlight) library. It covers more cases and properly works with html escaped input. See comparison table bellow.

### `Linkify` vs `Url highlight` comparison
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Linkify                                                                  | Url highlight                                                |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|--------------------------------------------------------------|
| Supported schemes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | ![](https://via.placeholder.com/10/d8c254/000000?text=+) http(s), ftp(s) | ![](https://via.placeholder.com/10/439e0a/000000?text=+) All |
| Simple url <br> <details>   <summary>Details</summary>   Simple url with scheme: `http://example.com`   <ul>     <li>Linkify: `<a href="http://example.com">http://example.com</a>`</li>     <li>Url highlight: `<a href="http://example.com">http://example.com</a>`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes             | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| No scheme <br> <details>   <summary>Details</summary>   Valid domain with no scheme: `example.com`   <ul>       <li>Linkify: `example.com`</li>     <li>Url highlight: `<a href="http://example.com">example.com</a>`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ![](https://via.placeholder.com/10/f03c15/000000?text=+) No              | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| No scheme with path <br> <details>   <summary>Details</summary>   Valid domain with no scheme with path: `example.com/path`   <ul>     <li>Linkify: `<a href="http://example.com/path">example.com/path</a>`</li>     <li>Url highlight: `<a href="http://example.com/path">example.com/path</a>`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes             | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| Invalid domain <br> <details>   <summary>Details</summary>   Not existing domain but string looks like url: `example.txt/path`   <ul>     <li>Linkify: `<a href="http://example.txt/path">example.txt/path</a>`</li>     <li>Url highlight: `example.txt/path`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | ![](https://via.placeholder.com/10/f03c15/000000?text=+) Yes             | ![](https://via.placeholder.com/10/439e0a/000000?text=+) No  |
| Email <br> <details>   <summary>Details</summary>   Generic email: `user@example.com`   <ul>     <li>Linkify: `<a href="mailto:user@example.com">user@example.com</a>`</li>     <li>Url highlight: `<a href="mailto:user@example.com">user@example.com</a>`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes             | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| Complex url <br><details>   <summary>Details</summary>   Urls could contain lots of special chars and brackets nesting. Example: `http://elk.example.com/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'deve-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc))`   <ul>     <li>Linkify: `<a href="http://elk.example.com/app/kibana#/discover?_g=()&_a=">http://elk.example.com/app/kibana#/discover?_g=()&_a=</a>(columns:!(_source),index:'deve-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc))`</li>     <li>Url highlight: `<a href="http://elk.example.com/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'deve-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc))">http://elk.example.com/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'deve-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc))</a>`</li>   </ul> </details> | ![](https://via.placeholder.com/10/f03c15/000000?text=+) No              | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| Url with userinfo <br> <details>   <summary>Details</summary>   Url could contain basic auth credentials: `http://user:password@example.com`   <ul>     <li>Linkify: `<a href="http://user:<a href="mailto:password@example.com">password@example.com</a>">http://user:<a href="mailto:password@example.com">password@example.com</a></a>`</li>     <li>Url highlight: `<a href="http://user:password@example.com">http://user:password@example.com</a>`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | ![](https://via.placeholder.com/10/f03c15/000000?text=+) No              | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |
| Html encoded input <br> <details>   <summary>Details</summary> Escaping html in string: `<b>http://example.com</b>` will result to: `&lt;b&gt;http://example.com&lt;/b&gt;`      <ul>     <li>Linkify: `&lt;b&gt;<a href="http://example.com&lt;/b&gt">http://example.com&lt;/b&gt</a>;`</li>     <li>Url highlight: `&lt;b&gt;<a href="http://example.com">http://example.com</a>&lt;/b&gt;`</li>   </ul> </details>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | ![](https://via.placeholder.com/10/f03c15/000000?text=+) No              | ![](https://via.placeholder.com/10/439e0a/000000?text=+) Yes |

#### Legend
 - ![](https://via.placeholder.com/10/439e0a/000000?text=+) - Proper match  
 - ![](https://via.placeholder.com/10/d8c254/000000?text=+) - Partial match  
 - ![](https://via.placeholder.com/10/f03c15/000000?text=+) - Invalid match

If this will be accepted - could prepare similar PR's for other versions.