### PR TITLE
Fixed null versionable_id + double versions on create

### DIFF
--- a/src/Model/EloquentFormRepository.php
+++ b/src/Model/EloquentFormRepository.php
@@ -91,12 +91,10 @@ class EloquentFormRepository implements FormRepositoryInterface
         if ($entry->getId()) {
             $entry->update($data);
         } else {
-            $entry = $entry->create($data);
+            $entry->fill($data)->save();
         }
 
         $entry->reguard();
-
-        $builder->setFormEntry($entry);
 
         $this->processSelfHandlingFields($builder);
 
@@ -107,7 +105,6 @@ class EloquentFormRepository implements FormRepositoryInterface
         if ($builder->versioningEnabled() && in_array(Versionable::class, $classes) && isset($enabled) && $enabled == true) {
             $entry->enableVersioning();
         }
-
     }
 
     /**

--- a/src/Ui/Form/Command/PostForm.php
+++ b/src/Ui/Form/Command/PostForm.php
@@ -54,8 +54,8 @@ class PostForm
 
         $this->dispatchNow(new LoadFormValues($this->builder));
         $this->dispatchNow(new RemoveSkippedFields($this->builder));
-        $this->dispatchNow(new HandleVersioning($this->builder));
         $this->dispatchNow(new HandleForm($this->builder));
+        $this->dispatchNow(new HandleVersioning($this->builder));
         $this->dispatchNow(new SetSuccessMessage($this->builder));
         $this->dispatchNow(new SetActionResponse($this->builder));
 


### PR DESCRIPTION
2 issues:

The version handle is dispatched before the form, so on create the entry has no id yet.

```
$this->dispatchNow(new HandleVersioning($this->builder));
$this->dispatchNow(new HandleForm($this->builder));
```

```
Column 'versionable_id' cannot be null
```

By switching the handles it's fix the problem.

---

Secondly, we create 2 versions on create (but not on update)

https://media.discordapp.net/attachments/748585596645015672/754694343142539275/Screenshot.png

The second come from `\Anomaly\Streams\Platform\Entry\EntryObserver::saved`. It's because $entry->create(), will create a new different object, so `versioningDisabled` is resetted.

![Screenshot](https://user-images.githubusercontent.com/2734125/93064773-22f77900-f6a2-11ea-9191-8cdb125a3780.png)

I used `->fill()->save()` instead. I'm just not sure about the observers (looks good for me).