### PR TITLE
added required secondary paramter for the MigrateCommand base class c…

### DIFF
--- a/src/Database/Migration/MigrationServiceProvider.php
+++ b/src/Database/Migration/MigrationServiceProvider.php
@@ -85,7 +85,7 @@ class MigrationServiceProvider extends \Illuminate\Database\MigrationServiceProv
         $this->app->singleton(
             'command.migrate',
             function ($app) {
-                return new MigrateCommand($app['migrator']);
+                return new MigrateCommand($app['migrator'], $app['events']);
             }
         );
     }


### PR DESCRIPTION
added required secondary paramter for the MigrateCommand base class constructor to prevent exception `Too few arguments`