### PR TITLE
1.8

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -202,7 +202,7 @@ class Application
     public function isInstalled()
     {
         if (is_null($this->installed)) {
-            $this->installed = file_exists(base_path('.env'));
+            $this->installed = env('INSTALLED');
         }
 
         return $this->installed;

--- a/src/Application/Command/InitializeApplication.php
+++ b/src/Application/Command/InitializeApplication.php
@@ -65,27 +65,24 @@ class InitializeApplication
          * then locate the application and
          * initialize.
          */
-        if ($application->isInstalled()) {
+        if (env('DB_CONNECTION', env('DB_DRIVER'))) {
 
-            if (env('DB_CONNECTION', env('DB_DRIVER'))) {
+            try {
 
-                try {
+                $application->setup();
 
+                if ($application->isInstalled()) {
                     if (PHP_SAPI != 'cli') {
                         $application->locate();
                     }
 
-                    $application->setup();
-
                     if (!$application->isEnabled()) {
                         abort(503);
                     }
-                } catch (\Exception $e) {
-                    // Do nothing.
                 }
+            } catch (\Exception $e) {
+                // Do nothing.
             }
-
-            return;
         }
     }
 }


### PR DESCRIPTION
`Application::isInstalled` is using `.env` which is not compatible on non `.env` environment (e.g. Docker & co). So the application is never installed (need to recreate a fake `.env` after each deployment~).

So I switched to `INSTALLED` like everything else. It's used in a single place anyway.

---------------

`InitializeApplication` is reworked a bit to take that in account (for `artisan build` when model are deleted).
