### PR TITLE
Fixed issue with Error

### DIFF
--- a/src/Exception/ExceptionIdentifier.php
+++ b/src/Exception/ExceptionIdentifier.php
@@ -1,6 +1,6 @@
 <?php namespace Anomaly\Streams\Platform\Exception;
 
-use Exception;
+use Throwable;
 
 /**
  * Class ExceptionIdentifier
@@ -26,11 +26,11 @@ class ExceptionIdentifier
     /**
      * Identify the given exception.
      *
-     * @param \Exception $exception
+     * @param Throwable $exception
      *
      * @return string
      */
-    public function identify(Exception $exception)
+    public function identify(Throwable $exception)
     {
         $hash = spl_object_hash($exception);
 


### PR DESCRIPTION
Fixed other Throwable (e.g. Error)

```
TypeError: Argument 1 passed to Anomaly\Streams\Platform\Exception\ExceptionIdentifier::identify() must be an instance of Exception, instance of TypeError given, called in /var/www/html/vendor/anomaly/streams-platform/src/Exception/ExceptionHandler.php on
```

