### PR TITLE
Fixed "Eloquent With" problem

### DIFF
--- a/src/Model/EloquentModel.php
+++ b/src/Model/EloquentModel.php
@@ -657,7 +657,7 @@ class EloquentModel extends Model implements Arrayable, PresentableInterface
             }
         }
 
-        return $attributes;
+        return array_merge($attributes, $this->relationsToArray());
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Model.php#L1483

The "with" used in Laravel does not work correctly for Pyrocms.

Problem details are below.

<img width="724" alt="Ekran Resmi 2022-11-03 14 23 17" src="https://user-images.githubusercontent.com/39536659/199710473-ed86c2c7-e726-4e33-ad9a-23557138e4d1.png">


![Ekran Resmi 2022-11-03 14 23 57](https://user-images.githubusercontent.com/39536659/199710451-25501e2f-68fc-413c-9173-73bc75d5a887.png)

![Ekran Resmi 2022-11-03 14 24 17](https://user-images.githubusercontent.com/39536659/199710490-bed8815e-767a-4455-b802-dd02e474bb9c.png)
